### PR TITLE
Fix preset removal

### DIFF
--- a/src/controller/oscqueryBridgeController.ts
+++ b/src/controller/oscqueryBridgeController.ts
@@ -1,7 +1,7 @@
 import { parse as parseQuery } from "querystring";
 import { readPacket } from "osc";
 import { initializeDevice, setParameterValue, setParameterValueNormalized } from "../actions/device";
-import { deleteEntity, setEntity } from "../actions/entities";
+import { clearEntities, deleteEntity, setEntity } from "../actions/entities";
 import { setConnectionStatus } from "../actions/network";
 import { AppDispatch, store } from "../lib/store";
 import { InportRecord } from "../models/inport";
@@ -88,11 +88,7 @@ export class OSCQueryBridgeControllerPrivate {
 			// Inports can be declared with just a name
 			dispatch(setEntity(EntityType.InportRecord, new InportRecord({ name: matches[2] })));
 		} else if (matches[1] === "presets/entries") {
-			console.log(path);
-			// fetch new preset?
-			this._ws.send(path);
-			// dispatch(setEntity(EntityType.PresetRecord, new PresetRecord({ name: matches })));
-			// eventually need to set PresetRecord once I can figure out what to put in it!
+			// @TODO
 		}
 	}
 
@@ -109,11 +105,9 @@ export class OSCQueryBridgeControllerPrivate {
 		} else if (matches[1] === "messages/in") {
 			const inPath = matches[2];
 			dispatch(deleteEntity(EntityType.InportRecord, inPath));
-		} else if (matches[1] === "presets") {
-			const prePath = matches[2];
-			dispatch(deleteEntity(EntityType.PresetRecord, prePath));
-			// dispatch delete
-			// console.log(matches);
+		} else if (matches[1] === "presets" && matches[2] === "entries") {
+			// clear all presets
+			dispatch(clearEntities(EntityType.PresetRecord));
 		}
 	}
 

--- a/src/models/preset.ts
+++ b/src/models/preset.ts
@@ -14,12 +14,13 @@ export class PresetRecord extends ImmuRecord({
 	 * @returns An Immutable List of PresetRecord record objects
 	 */
 	static arrayFromDescription(desc: JsonMap): PresetRecord[] {
+
 		const entries = ((desc.entries as JsonMap).VALUE as any);
 		const current = ((desc.entries as JsonMap).VALUE as string);
+
 		if (Array.isArray(entries)) {
 			return entries.map(name => {
-				let loaded = (name === current);
-				return new PresetRecord({name, loaded})
+				return new PresetRecord({name, loaded: name === current });
 			});
 		}
 		return [];


### PR DESCRIPTION
currently when reexporting we were deleting presets "del" "load" "save" etc although these were just "paths" not actual preset entries. This PR just clears the whole Preset entity list.