### PR TITLE
More generic System node creation

### DIFF
--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -150,6 +150,9 @@ export const initGraph = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 			devices.push(DeviceStateRecord.fromDescription(value));
 		}
 
+
+		// Build a list of all Jack generated names that have not been used for PatcherNodes above
+		// as we assume moving forward that they are SystemNames
 		const systemJackNames = ImmuSet<string>(getSystemNodeJackNamesFromPortInfo(jackPortsInfo, patcherNodes));
 
 		for (const node of patcherNodes) {

--- a/src/components/editor/systemNode.tsx
+++ b/src/components/editor/systemNode.tsx
@@ -21,7 +21,7 @@ const EditorSystemNode: FunctionComponent<EditorNodeProps> = memo(function Wrapp
 	return (
 		<Paper className={ classes.node }  shadow="sm" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
-				{ node.name }
+				{ node.id }
 			</div>
 			<div className={ classes.nodeContent } style={{ height: `${contentHeight}px` }} >
 				{

--- a/src/controller/oscqueryBridgeController.ts
+++ b/src/controller/oscqueryBridgeController.ts
@@ -8,7 +8,7 @@ import { OSCQueryRNBOInstance, OSCQueryRNBOInstancesState, OSCQueryRNBOJackPortI
 import { addPatcherNode, initGraph, removePatcherNode, updatePatcherNodeSinkPortConnections, updatePatcherNodeSourcePortConnections } from "../actions/graph";
 import { initPatchers } from "../actions/patchers";
 import { sleep } from "../lib/util";
-import { getNodeByIndex } from "../selectors/graph";
+import { getPatcherNodeByIndex } from "../selectors/graph";
 import { updateDeviceInstanceMessageOutputValue, updateDeviceInstanceMessages, updateDeviceInstanceParameterValue, updateDeviceInstanceParameterValueNormalized, updateDeviceInstanceParameters, updateDeviceInstancePresetEntries } from "../actions/instances";
 
 const dispatch = store.dispatch as AppDispatch;
@@ -26,7 +26,7 @@ const oscPacketAddressMatcher = /^\/rnbo\/inst\/(?<index>\d+)\/(?<content>params
 export class OSCQueryBridgeControllerPrivate {
 
 	private static instanceExists(index: number): boolean {
-		return !!getNodeByIndex(store.getState(), index);
+		return !!getPatcherNodeByIndex(store.getState(), index);
 	}
 
 	private _ws: ReconnectingWebsocket | null = null;

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -343,11 +343,14 @@ export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 		});
 	}
 
-	static fromDescription(systemJackName: ImmuSet<string>, desc: OSCQueryRNBOJackPortInfo): GraphSystemNodeRecord[] {
+	static fromDescription(systemJackNames: ImmuSet<string>, desc: OSCQueryRNBOJackPortInfo): GraphSystemNodeRecord[] {
 
+		// We expect systemJackNames to be a Set of all, non device instances jack assigned names
+		// in order to be able to filter out the global Jack Port description for creating SystemNodes.
+		// This is necessary as SystemNodes, in contrast to device instances, don't have a dedicated tree desc
 		const nodes: GraphSystemNodeRecord[] = [];
 
-		for (const jackName of systemJackName.valueSeq().toArray()) {
+		for (const jackName of systemJackNames.valueSeq().toArray()) {
 
 			const inputPorts = this.sourcesFromDescription(jackName, desc);
 			const outputPorts = this.sinksFromDescription(jackName, desc);
@@ -437,6 +440,11 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 		desc: OSCQueryRNBOInstanceConnections,
 		systemNodeJackNames: ImmuSet<GraphSystemNodeRecord["jackName"]>
 	): GraphConnectionRecord[] {
+
+		// Expect a list of systemNodeJackNames in order to be able to set up the correct
+		// connections as we make two nodes for each SystemNode in the graph - an Input and an Output
+		// by adding a static suffix to the jackName of the node.
+
 		const conns: GraphConnectionRecord[] = [];
 
 		// Patcher Node as Source

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -1,5 +1,5 @@
 
-import { Record as ImmuRecord, Map as ImmuMap } from "immutable";
+import { Record as ImmuRecord, Map as ImmuMap, Set as ImmuSet } from "immutable";
 import { OSCQueryRNBOInstance, OSCQueryRNBOInstanceConnections, OSCQueryRNBOJackPortInfo } from "../lib/types";
 
 export enum ConnectionType {
@@ -58,7 +58,9 @@ export type CommonGraphNodeProps = {
 }
 
 export type GraphSystemNodeProps = CommonGraphNodeProps & {
-	name: string;
+	direction: PortDirection;
+	id: string;
+	jackName: string;
 }
 
 export type GraphPatcherNodeProps = CommonGraphNodeProps & {
@@ -214,7 +216,9 @@ export class GraphPatcherNodeRecord extends ImmuRecord<GraphPatcherNodeProps>({
 
 export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 
-	name: "",
+	direction: PortDirection.Source,
+	id: "",
+	jackName: "",
 	ports: ImmuMap<GraphPortRecord["id"], GraphPortRecord>(),
 
 	// Editor props
@@ -227,10 +231,6 @@ export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 
 	public getPort(id: GraphPortRecord["id"]): GraphPortRecord | undefined {
 		return this.ports.get(id);
-	}
-
-	get id(): string {
-		return this.name;
 	}
 
 	get type(): NodeType.System {
@@ -261,79 +261,16 @@ export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 		return this.set("selected", !this.selected);
 	}
 
-	static get systemAudioName(): string {
-		return "system";
+	public static get inputSuffix(): string {
+		return "-in";
 	}
 
-
-	static get systemMIDIName(): string {
-		return "system_midi";
+	public static get outputSuffix(): string {
+		return "-out";
 	}
 
-	static get systemAudioOutputName(): string {
-		return `${this.systemAudioName}_audio-out`;
-	}
-
-	static get systemAudioInputName(): string {
-		return `${this.systemAudioName}_audio-in`;
-	}
-
-	static get systemMIDIOutputName(): string {
-		return `${this.systemMIDIName}-out`;
-	}
-
-	static get systemMIDIInputName(): string {
-		return `${this.systemMIDIName}-in`;
-	}
-
-	private static audioSinksFromDescription(desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
-
-		const portNameReplace = `${this.systemAudioName}:`;
-
-		return ImmuMap<GraphPortRecord["id"], GraphPortRecord>().withMutations(ports => {
-			if (
-				desc.CONTENTS.audio.CONTENTS.sinks.TYPE !== "" &&
-				desc.CONTENTS.audio.CONTENTS.sinks.VALUE.length
-			) {
-				for (const portName of desc.CONTENTS.audio.CONTENTS.sinks.VALUE) {
-					if (portName.startsWith(portNameReplace)) {
-						const port = new GraphPortRecord({
-							id: portName.replace(portNameReplace, ""),
-							direction: PortDirection.Sink,
-							type: ConnectionType.Audio
-						});
-						ports.set(port.id, port);
-					}
-				}
-			}
-		});
-	}
-
-	private static midiSinksFromDescription(desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
-
-		const portNameReplace = `${this.systemMIDIName}:`;
-
-		return ImmuMap<GraphPortRecord["id"], GraphPortRecord>().withMutations(ports => {
-			if (
-				desc.CONTENTS.midi.CONTENTS.sinks.TYPE !== "" &&
-				desc.CONTENTS.midi.CONTENTS.sinks.VALUE.length
-			) {
-				for (const portName of desc.CONTENTS.midi.CONTENTS.sinks.VALUE) {
-					if (portName.startsWith(portNameReplace)) {
-						const port = new GraphPortRecord({
-							id: portName.replace(portNameReplace, ""),
-							direction: PortDirection.Sink,
-							type: ConnectionType.MIDI
-						});
-						ports.set(port.id, port);
-					}
-				}
-			}
-		});
-	}
-
-	private static audioSourcesFromDescription(desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
-		const portNameReplace = `${this.systemAudioName}:`;
+	private static sourcesFromDescription(nodeName: string, desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
+		const portNameReplace = `${nodeName}:`;
 		return ImmuMap<GraphPortRecord["id"], GraphPortRecord>().withMutations(ports => {
 			if (
 				desc.CONTENTS.audio.CONTENTS.sources.TYPE !== "" &&
@@ -369,18 +306,34 @@ export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 		});
 	}
 
-	private static midiSourcesFromDescription(desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
-		const portNameReplace = `${this.systemMIDIName}:`;
+	private static sinksFromDescription(nodeName: string, desc: OSCQueryRNBOJackPortInfo): ImmuMap<GraphPortRecord["id"], GraphPortRecord> {
+		const portNameReplace = `${nodeName}:`;
 		return ImmuMap<GraphPortRecord["id"], GraphPortRecord>().withMutations(ports => {
 			if (
-				desc.CONTENTS.midi.CONTENTS.sources.TYPE !== "" &&
-				desc.CONTENTS.midi.CONTENTS.sources.VALUE.length
+				desc.CONTENTS.audio.CONTENTS.sinks.TYPE !== "" &&
+				desc.CONTENTS.audio.CONTENTS.sinks.VALUE.length
 			) {
-				for (const portName of desc.CONTENTS.midi.CONTENTS.sources.VALUE) {
+				for (const portName of desc.CONTENTS.audio.CONTENTS.sinks.VALUE) {
 					if (portName.startsWith(portNameReplace)) {
 						const port = new GraphPortRecord({
 							id: portName.replace(portNameReplace, ""),
-							direction: PortDirection.Source,
+							direction: PortDirection.Sink,
+							type: ConnectionType.Audio
+						});
+						ports.set(port.id, port);
+					}
+				}
+			}
+
+			if (
+				desc.CONTENTS.midi.CONTENTS.sinks.TYPE !== "" &&
+				desc.CONTENTS.midi.CONTENTS.sinks.VALUE.length
+			) {
+				for (const portName of desc.CONTENTS.midi.CONTENTS.sinks.VALUE) {
+					if (portName.startsWith(portNameReplace)) {
+						const port = new GraphPortRecord({
+							id: portName.replace(portNameReplace, ""),
+							direction: PortDirection.Sink,
 							type: ConnectionType.MIDI
 						});
 						ports.set(port.id, port);
@@ -390,52 +343,46 @@ export class GraphSystemNodeRecord extends ImmuRecord<GraphSystemNodeProps>({
 		});
 	}
 
-	static fromDescription(desc: OSCQueryRNBOJackPortInfo): GraphSystemNodeRecord[] {
-		// System Audio Input
-		const audioInputPorts = this.audioSourcesFromDescription(desc);
-		const audioInput = new GraphSystemNodeRecord({
-			name: this.systemAudioInputName,
-			ports: audioInputPorts,
-			contentHeight: calculateContentHeight(audioInputPorts),
-			selected: false,
-			x: 0,
-			y: 0
-		});
+	static fromDescription(systemJackName: ImmuSet<string>, desc: OSCQueryRNBOJackPortInfo): GraphSystemNodeRecord[] {
 
-		// System Audio Output
-		const audioOutputPorts = this.audioSinksFromDescription(desc);
-		const audioOutput = new GraphSystemNodeRecord({
-			name: this.systemAudioOutputName,
-			ports: audioOutputPorts,
-			contentHeight: calculateContentHeight(audioOutputPorts),
-			selected: false,
-			x: 0,
-			y: 0
-		});
+		const nodes: GraphSystemNodeRecord[] = [];
 
-		// System MIDI Input
-		const midiInputPorts = this.midiSourcesFromDescription(desc);
-		const midiInput = new GraphSystemNodeRecord({
-			name: this.systemMIDIInputName,
-			ports: midiInputPorts,
-			contentHeight: calculateContentHeight(midiInputPorts),
-			selected: false,
-			x: 0,
-			y: 0
-		});
+		for (const jackName of systemJackName.valueSeq().toArray()) {
 
-		// System Audio Output
-		const midiOutputPorts = this.midiSinksFromDescription(desc);
-		const midiOutput = new GraphSystemNodeRecord({
-			name: this.systemMIDIOutputName,
-			ports: midiOutputPorts,
-			contentHeight: calculateContentHeight(midiOutputPorts),
-			selected: false,
-			x: 0,
-			y: 0
-		});
+			const inputPorts = this.sourcesFromDescription(jackName, desc);
+			const outputPorts = this.sinksFromDescription(jackName, desc);
+			if (inputPorts.size) {
+				nodes.push(
+					new GraphSystemNodeRecord({
+						jackName,
+						direction: PortDirection.Source,
+						id: `${jackName}${this.inputSuffix}`,
+						ports: inputPorts,
+						contentHeight: calculateContentHeight(inputPorts),
+						selected: false,
+						x: 0,
+						y: 0
+					})
+				);
+			}
 
-		return [audioInput, audioOutput, midiInput, midiOutput];
+			if (outputPorts.size) {
+				nodes.push(
+					new GraphSystemNodeRecord({
+						jackName,
+						direction: PortDirection.Sink,
+						id: `${jackName}${this.outputSuffix}`,
+						ports: outputPorts,
+						contentHeight: calculateContentHeight(outputPorts),
+						selected: false,
+						x: 0,
+						y: 0
+					})
+				);
+			}
+		}
+
+		return nodes;
 	}
 }
 
@@ -485,7 +432,11 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 		return `${sourceId}:${sourcePortId}${this.connectionDelimiter}${sinkId}:${sinkPortId}`;
 	}
 
-	public static patcherNodeConnectionsFromDescription(nodeId: GraphNodeRecord["id"], desc: OSCQueryRNBOInstanceConnections): GraphConnectionRecord[] {
+	public static patcherNodeConnectionsFromDescription(
+		nodeId: GraphNodeRecord["id"],
+		desc: OSCQueryRNBOInstanceConnections,
+		systemNodeJackNames: ImmuSet<GraphSystemNodeRecord["jackName"]>
+	): GraphConnectionRecord[] {
 		const conns: GraphConnectionRecord[] = [];
 
 		// Patcher Node as Source
@@ -501,7 +452,7 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 				const [sinkNodeId, sinkPortId] = target.split(":");
 				return new GraphConnectionRecord({
 					...commonConnProps,
-					sinkNodeId: sinkNodeId === GraphSystemNodeRecord.systemAudioName ? GraphSystemNodeRecord.systemAudioOutputName : sinkNodeId,
+					sinkNodeId: systemNodeJackNames.has(sinkNodeId) ? `${sinkNodeId}${GraphSystemNodeRecord.outputSuffix}` : sinkNodeId,
 					sinkPortId
 				});
 			})));
@@ -519,7 +470,7 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 				const [sinkNodeId, sinkPortId] = target.split(":");
 				return new GraphConnectionRecord({
 					...commonConnProps,
-					sinkNodeId: sinkNodeId === GraphSystemNodeRecord.systemMIDIName ? GraphSystemNodeRecord.systemMIDIOutputName : sinkNodeId,
+					sinkNodeId: systemNodeJackNames.has(sinkNodeId) ? `${sinkNodeId}${GraphSystemNodeRecord.outputSuffix}` : sinkNodeId,
 					sinkPortId
 				});
 			})));
@@ -536,10 +487,10 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 
 			for (const target of info.VALUE) {
 				const [soureNodeId, sourcePortId] = target.split(":");
-				if (soureNodeId !== GraphSystemNodeRecord.systemAudioName) continue;
+				if (!systemNodeJackNames.has(soureNodeId)) continue;
 				conns.push(new GraphConnectionRecord({
 					...commonConnProps,
-					sourceNodeId: GraphSystemNodeRecord.systemAudioInputName,
+					sourceNodeId: `${soureNodeId}${GraphSystemNodeRecord.inputSuffix}`,
 					sourcePortId
 				}));
 			}
@@ -555,10 +506,10 @@ export class GraphConnectionRecord extends ImmuRecord<GraphConnectionProps>({
 
 			for (const target of info.VALUE) {
 				const [soureNodeId, sourcePortId] = target.split(":");
-				if (soureNodeId !== GraphSystemNodeRecord.systemMIDIName) continue;
+				if (!systemNodeJackNames.has(soureNodeId)) continue;
 				conns.push(new GraphConnectionRecord({
 					...commonConnProps,
-					sourceNodeId: GraphSystemNodeRecord.systemMIDIInputName,
+					sourceNodeId: `${soureNodeId}${GraphSystemNodeRecord.inputSuffix}`,
 					sourcePortId
 				}));
 			}

--- a/src/selectors/graph.ts
+++ b/src/selectors/graph.ts
@@ -1,17 +1,22 @@
-import { Map as ImmuMap, Seq } from "immutable";
+import { Map as ImmuMap, Seq, Set as ImmuSet } from "immutable";
 import { RootStateType } from "../lib/store";
-import { GraphConnectionRecord, GraphNodeRecord, GraphPatcherNodeRecord, GraphSystemNodeRecord, NodeType } from "../models/graph";
+import { GraphConnectionRecord, GraphNodeRecord, GraphPatcherNodeRecord, GraphSystemNodeRecord, NodeType, PortDirection } from "../models/graph";
 
 export const getNode = (state: RootStateType, id: GraphNodeRecord["id"]): GraphNodeRecord | undefined => state.graph.nodes.get(id);
 export const getNodes = (state: RootStateType): ImmuMap<GraphNodeRecord["id"], GraphNodeRecord> => state.graph.nodes;
-export const getNodeByIndex = (state: RootStateType, index: GraphPatcherNodeRecord["index"]): GraphPatcherNodeRecord | undefined => {
+
+export const getPatcherNodes = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["id"], GraphPatcherNodeRecord> => {
+	return state.graph.nodes.filter(node => node.type === NodeType.Patcher) as ImmuMap<GraphPatcherNodeRecord["id"], GraphPatcherNodeRecord>;
+};
+
+export const getPatcherNodeByIndex = (state: RootStateType, index: GraphPatcherNodeRecord["index"]): GraphPatcherNodeRecord | undefined => {
 	const id = state.graph.patcherNodeIdByIndex.get(index);
 	const node = id ? state.graph.nodes.get(id) : undefined;
 	return node as GraphPatcherNodeRecord | undefined;
 };
 
-export const getPatcherNodes = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["id"], GraphPatcherNodeRecord> => {
-	return state.graph.nodes.filter(node => node.type === NodeType.Patcher) as ImmuMap<GraphPatcherNodeRecord["id"], GraphPatcherNodeRecord>;
+export const getFirstPatcherNodeIndex = (state: RootStateType): number | undefined => {
+	return state.graph.patcherNodeIdByIndex.keySeq().sort().first();
 };
 
 export const getPatcherNodesByIndex = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord> => {
@@ -23,12 +28,20 @@ export const getPatcherNodesByIndex = (state: RootStateType): ImmuMap<GraphPatch
 	});
 };
 
-export const getFirstPatcherNodeIndex = (state: RootStateType): number | undefined => {
-	return state.graph.patcherNodeIdByIndex.keySeq().sort().first();
-};
-
 export const getSystemNodes = (state: RootStateType): ImmuMap<GraphSystemNodeRecord["id"], GraphSystemNodeRecord> => {
 	return state.graph.nodes.filter(node => node.type === NodeType.System) as ImmuMap<GraphSystemNodeRecord["id"], GraphSystemNodeRecord>;
+};
+
+export const getSystemNodeByJackNameAndDirection = (state: RootStateType, jackName: GraphSystemNodeRecord["jackName"], direction: PortDirection): GraphSystemNodeRecord | undefined => {
+	return state.graph.nodes.find(node => node.type === NodeType.System && node.jackName === jackName && node.direction === direction) as GraphSystemNodeRecord | undefined;
+};
+
+export const getSystemNodesJackNames = (state: RootStateType): ImmuSet<GraphSystemNodeRecord["jackName"]> => {
+	return ImmuSet<GraphSystemNodeRecord["jackName"]>().withMutations(result => {
+		for (const node of state.graph.nodes.valueSeq().toArray()) {
+			if (node.type === NodeType.System) result.add(node.jackName);
+		}
+	});
 };
 
 export const getConnection = (state: RootStateType, id: GraphConnectionRecord["id"]): GraphConnectionRecord | undefined => state.graph.connections.get(id);


### PR DESCRIPTION
As discussed in #48 this parses the Jack info by filtering out the port names used for instances rather than relying upon `system` and `system_midi` being used as jack names to allow more generic system node support