### PR TITLE
Improved enum parameter handling

### DIFF
--- a/src/components/parameter/item.tsx
+++ b/src/components/parameter/item.tsx
@@ -27,7 +27,8 @@ const Parameter = memo(function WrappedParameter({ param, onSetNormalizedValue }
 	}, [setUseLocalValue, onSetNormalizedValue, param]);
 
 	const currentValue = useLocalValue ? localValue : param.normalizedValue;
-	const displayValue = typeof param.value === "number" ? param.value.toFixed(2) : param.value;
+	const displayValue = param.getDisplayValueForNormalizedValue(currentValue);
+	const stepSize = param.isEnum ? 1 / (param.enumVals.length - 1) : 0.001;
 
 	return (
 		<div className={ classes.parameterItem } >
@@ -41,9 +42,14 @@ const Parameter = memo(function WrappedParameter({ param, onSetNormalizedValue }
 				name={ param.name }
 				onChange={ onChange }
 				onChangeEnd={ onChangeEnd }
-				precision={ 2 }
-				step={ 0.001 }
+				precision={ 3 }
+				step={ stepSize }
 				value={ currentValue }
+				marks={
+					param.isEnum
+						? param.enumVals.map((v, i) => ({ label: `${v}`, value: stepSize * i }))
+						: [{ label: `${param.min}`, value: 0 }, { label: `${param.max}`, value: 1 }]
+				}
 			/>
 		</div>
 	);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -209,7 +209,7 @@ export type OSCQueryRNBOInstanceParameterValue = OSCQueryBaseNode & OSCQueryFloa
 	CONTENTS: {
 		normalized: OSCQueryFloatValue & OSCQueryValueRange & { VALUE: number; }
 	};
-	VALUE: number;
+	VALUE: number | string;
 };
 
 export type OSCQueryRNBOInstanceParameterInfo = OSCQueryRNBOInstanceParameterValue | {

--- a/src/models/parameter.ts
+++ b/src/models/parameter.ts
@@ -28,7 +28,6 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 		const result: ParameterRecord[] = [];
 		if (typeof desc.VALUE !== "undefined") {
 			const paramInfo = desc as OSCQueryRNBOInstanceParameterValue;
-			console.log(paramInfo);
 			result.push(new ParameterRecord({
 				enumVals: paramInfo.RANGE?.[0]?.VALS || [],
 				min: paramInfo.RANGE?.[0]?.MIN,

--- a/src/models/parameter.ts
+++ b/src/models/parameter.ts
@@ -2,16 +2,18 @@ import { Record as ImmuRecord } from "immutable";
 import { OSCQueryRNBOInstanceParameterInfo, OSCQueryRNBOInstanceParameterValue } from "../lib/types";
 
 export type ParameterRecordProps = {
+	enumVals: Array<string | number>;
 	min: number;
 	max: number;
 	name: string;
 	normalizedValue: number;
 	path: string;
 	type: string;
-	value: number;
+	value: string | number;
 }
 export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 
+	enumVals: [],
 	min: 0,
 	max: 1,
 	name: "name",
@@ -26,7 +28,9 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 		const result: ParameterRecord[] = [];
 		if (typeof desc.VALUE !== "undefined") {
 			const paramInfo = desc as OSCQueryRNBOInstanceParameterValue;
+			console.log(paramInfo);
 			result.push(new ParameterRecord({
+				enumVals: paramInfo.RANGE?.[0]?.VALS || [],
 				min: paramInfo.RANGE?.[0]?.MIN,
 				max: paramInfo.RANGE?.[0]?.MAX,
 				name,
@@ -47,6 +51,16 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 
 	public get id(): string {
 		return this.name;
+	}
+
+	public get isEnum(): boolean {
+		return this.enumVals.length >= 1;
+	}
+
+	public getDisplayValueForNormalizedValue(nv: number): string | number {
+		if (this.isEnum) return this.enumVals[Math.round((this.enumVals.length - 1 ) * nv)];
+
+		return typeof this.value !== "number" ? this.value : this.value.toFixed(2);
 	}
 
 	public setValue(v: number): ParameterRecord {

--- a/src/models/parameter.ts
+++ b/src/models/parameter.ts
@@ -45,31 +45,6 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 		return result;
 	}
 
-	// public static arrayFromDescription(desc: JsonMap, prefix?: string): ParameterRecord[] {
-
-	// 	if (typeof desc.VALUE !== "undefined") {
-
-	// 		const parameterRecord = new ParameterRecord({
-	// 			name: prefix,
-	// 			value: (desc.VALUE as number),
-	// 			min: ((desc.RANGE as JsonMap[])[0].MIN as number),
-	// 			max: ((desc.RANGE as JsonMap[])[0].MAX as number),
-	// 			type: (desc.TYPE as string),
-	// 			normalizedValue: (((desc.CONTENTS as JsonMap).normalized as JsonMap).VALUE as number)
-	// 		});
-
-	// 		return [parameterRecord];
-	// 	}
-
-	// 	const nextDesc = desc.CONTENTS as JsonMap;
-	// 	const subparamNames = Object.getOwnPropertyNames(nextDesc);
-	// 	const subparamLists = subparamNames.map(subparamName => {
-	// 		const nextPrefix = prefix ? `${prefix}/${subparamName}` : subparamName;
-	// 		return this.arrayFromDescription(nextDesc[subparamName] as JsonMap, nextPrefix);
-	// 	});
-	// 	return subparamLists.reduce((acc, l) => acc.concat(l), []);
-	// }
-
 	public get id(): string {
 		return this.name;
 	}


### PR DESCRIPTION
This adds slider markers and stepped movement for enum parameters.

One thing I noticed is that `[param]` objects without `@min` and `@max` basically default to a 0 - 1 range and seem to report their value within that range only. Maybe expected due to the lack of more info and the "fix" is to recommend setting the min and max attributes but thought I'd mention

Closes #61 