### PR TITLE
Minor tweak to Graph Editor Display

### DIFF
--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -26,7 +26,7 @@ const getPatcherOrControlNodeCoordinates = (node: GraphPatcherNodeRecord | Graph
 	}, undefined as GraphNodeRecord | undefined);
 
 	const y = bottomNode ? bottomNode.y + bottomNode.height + defaultNodeSpacing : 0;
-	return { x: 300 + defaultNodeSpacing, y };
+	return { x: 435 + defaultNodeSpacing, y };
 };
 
 const serializeSetMeta = (nodes: GraphNodeRecord[]): string => {
@@ -431,7 +431,7 @@ export const initNodes = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 					systemInputY = node.y + node.contentHeight;
 				} else {
 					node = node.updatePosition(
-						(node.width + defaultNodeSpacing ) * 2,
+						node.width + 300 + defaultNodeSpacing * 2,
 						systemOutputY + defaultNodeSpacing
 					);
 					systemOutputY = node.y + node.contentHeight;
@@ -588,7 +588,7 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 					systemInputY = node.y + node.contentHeight;
 				} else {
 					node = node.updatePosition(
-						(node.width + defaultNodeSpacing ) * 2,
+						node.width + 300 + defaultNodeSpacing * 2,
 						systemOutputY + defaultNodeSpacing
 					);
 					systemOutputY = node.y + node.contentHeight;

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -26,7 +26,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		<Paper className={ classes.node } shadow="sm" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				<div>
-					{ (node as GraphPatcherNodeRecord).patcher }
+					{ (node as GraphPatcherNodeRecord).index }: { (node as GraphPatcherNodeRecord).patcher }
 				</div>
 				<div>
 					<ActionIcon

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -37,7 +37,7 @@ export class GraphPortRecord extends ImmuRecord<GraphPortProps> ({
 const headerHeight = 50;
 const portHeight = 20;
 const portSpacing = 30;
-const nodeWidth = 300;
+const nodeWidth = 435;
 
 export const calculateNodeContentHeight = (ports: ImmuMap<GraphPortRecord["id"], GraphPortRecord>): number => {
 	const { sinkCount, sourceCount } = ports.valueSeq().reduce((result, port) => {


### PR DESCRIPTION
This adds the instance's index to an instance node in the graph view and improves the system node placement for a bit more space. The latter is more of a cosmetic tweak after the widened system nodes for improved I/O naming rather than an elaborate algorithm to calculate the positions but should be enough for now to make it more usable from the get go.