### PR TITLE
UX Tweaks

### DIFF
--- a/src/components/editor/controlNode.tsx
+++ b/src/components/editor/controlNode.tsx
@@ -18,7 +18,7 @@ const EditorControlNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
 	return (
-		<Paper className={ classes.node } shadow="sm" withBorder data-selected={ selected } >
+		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.id }
 			</div>

--- a/src/components/editor/editor.module.css
+++ b/src/components/editor/editor.module.css
@@ -37,6 +37,20 @@
 .editor {
 	flex: 1;
 
+	&[data-color-scheme="light"] {
+		.node {
+			background-color: var(--mantine-color-gray-1);
+			border-color: var(--mantine-color-gray-5);
+		}
+	}
+
+	&[data-color-scheme="dark"] {
+		.node {
+			background-color: var(--mantine-color-gray-8);
+			border-color: var(--mantine-color-gray-6);
+		}
+	}
+
 	:global {
 
 		.react-flow__attribution {
@@ -89,7 +103,6 @@
 
 			&:before,
 			&:after {
-				color: var(--mantine-color-dimmed);
 				font-size: var(--mantine-font-size-sm);
 				overflow: hidden;
 				position: absolute;

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -12,6 +12,7 @@ import classes from "./editor.module.css";
 import GraphEdge, { RNBOGraphEdgeType } from "./edge";
 import { useRouter } from "next/router";
 import EditorControlNode from "./controlNode";
+import { useMantineColorScheme } from "@mantine/core";
 
 export type GraphEditorProps = {
 	connections: RootStateType["graph"]["connections"];
@@ -43,6 +44,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 	onEdgesDelete
 }) {
 
+	const { colorScheme } = useMantineColorScheme();
 	const { push, query } = useRouter();
 
 	// Validate Connection Directions and Types
@@ -93,7 +95,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 	}));
 
 	return (
-		<div className={ classes.editor } >
+		<div className={ classes.editor } data-color-scheme={ colorScheme } >
 			<ReactFlow
 				isValidConnection={ validateConnection }
 				edges={ flowEdges }

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -23,7 +23,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
 	return (
-		<Paper className={ classes.node } shadow="sm" withBorder data-selected={ selected } >
+		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				<div>
 					{ (node as GraphPatcherNodeRecord).index }: { (node as GraphPatcherNodeRecord).patcher }

--- a/src/components/editor/systemNode.tsx
+++ b/src/components/editor/systemNode.tsx
@@ -27,7 +27,7 @@ const EditorSystemNode: FunctionComponent<EditorNodeProps> = memo(function Wrapp
 	}, 0);
 
 	return (
-		<Paper className={ classes.node }  shadow="sm" withBorder data-selected={ selected } >
+		<Paper className={ classes.node }  shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.jackName }
 			</div>

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, ChangeEvent, KeyboardEvent, MouseEvent, FormEvent, memo, useCallback, useState, useRef, useEffect } from "react";
-import { ActionIcon, Group, TextInput } from "@mantine/core";
+import { ActionIcon, Button, Group, Menu, TextInput } from "@mantine/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faClose, faPen, faTrash, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faClose, faEllipsisVertical, faPen, faTrash, faUpload } from "@fortawesome/free-solid-svg-icons";
 import classes from "./presets.module.css";
 import { PresetRecord } from "../../models/preset";
 import { keyEventIsValidForName, replaceInvalidNameChars } from "../../lib/util";
@@ -75,7 +75,7 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 		<form onSubmit={ onRenamePreset } >
 			<Group align="flex-start">
 				<TextInput
-					className={ classes.presetItemName }
+					className={ classes.presetNameInput }
 					onChange={ onChange }
 					onKeyDown={ onKeyDown }
 					ref={ inputRef }
@@ -95,19 +95,30 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 			</Group>
 		</form>
 	) : (
-		<Group>
-			<TextInput className={ classes.presetItemName } readOnly variant="unstyled" value={ preset.name } size="sm" />
-			<ActionIcon.Group>
-				<ActionIcon variant="subtle" color="red" size="md" onClick={ onDeletePreset } >
-					<FontAwesomeIcon icon={ faTrash } />
-				</ActionIcon>
-				<ActionIcon variant="subtle" size="md" color="gray" onClick={ toggleEditing } >
-					<FontAwesomeIcon icon={ faPen } />
-				</ActionIcon>
-				<ActionIcon variant="subtle" size="md" onClick={ onLoadPreset } >
-					<FontAwesomeIcon icon={ faUpload } />
-				</ActionIcon>
-			</ActionIcon.Group>
+		<Group gap="xs">
+			<Button
+				className={ classes.presetButton }
+				color="gray"
+				justify="flex-start"
+				size="sm"
+				variant="outline"
+				leftSection={ <FontAwesomeIcon icon={ faUpload } /> }
+				onClick={ onLoadPreset }
+			>
+				{ preset.name }
+			</Button>
+			<Menu position="bottom-end" >
+				<Menu.Target>
+					<ActionIcon variant="subtle" color="gray">
+						<FontAwesomeIcon icon={ faEllipsisVertical } />
+					</ActionIcon>
+				</Menu.Target>
+				<Menu.Dropdown>
+					<Menu.Label>Actions</Menu.Label>
+					<Menu.Item leftSection={ <FontAwesomeIcon icon={ faPen } /> } onClick={ toggleEditing } >Rename</Menu.Item>
+					<Menu.Item color="red" leftSection={ <FontAwesomeIcon icon={ faTrash } /> } onClick={ onDeletePreset } >Delete</Menu.Item>
+				</Menu.Dropdown>
+			</Menu>
 		</Group>
 	);
 });

--- a/src/components/presets/presets.module.css
+++ b/src/components/presets/presets.module.css
@@ -1,3 +1,7 @@
-.presetItemName {
+.presetButton {
+	flex: 1;
+}
+
+.presetNameInput {
 	flex: 1;
 }

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -1,8 +1,8 @@
 import { ChangeEvent, FormEvent, FunctionComponent, KeyboardEvent, MouseEvent, memo, useCallback, useEffect, useRef, useState } from "react";
 import { GraphSetRecord } from "../../models/set";
-import { ActionIcon, Group, TextInput } from "@mantine/core";
+import { ActionIcon, Button, Group, Menu, TextInput } from "@mantine/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faClose, faPen, faTrash, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faClose, faEllipsisVertical, faPen, faTrash, faUpload } from "@fortawesome/free-solid-svg-icons";
 import classes from "./sets.module.css";
 import { keyEventIsValidForName, replaceInvalidNameChars } from "../../lib/util";
 
@@ -84,7 +84,7 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 		<form onSubmit={ onRenameSet } >
 			<Group align="flex-start">
 				<TextInput
-					className={ classes.setItemName }
+					className={ classes.setItemNameInput }
 					onChange={ onChange }
 					onKeyDown={ onKeyDown }
 					ref={ inputRef }
@@ -104,19 +104,31 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 			</Group>
 		</form>
 	) : (
-		<Group>
-			<TextInput className={ classes.setItemName } readOnly variant="unstyled" value={ name } size="sm" />
-			<ActionIcon.Group>
-				<ActionIcon variant="subtle" color="red" size="md" onClick={ onDeleteSet } >
-					<FontAwesomeIcon icon={ faTrash } />
-				</ActionIcon>
-				<ActionIcon variant="subtle" size="md" color="gray" onClick={ toggleEditing } >
-					<FontAwesomeIcon icon={ faPen } />
-				</ActionIcon>
-				<ActionIcon variant="subtle" size="md" onClick={ onLoadSet } >
-					<FontAwesomeIcon icon={ faUpload } />
-				</ActionIcon>
-			</ActionIcon.Group>
+
+		<Group gap="xs">
+			<Button
+				className={ classes.setItemButton }
+				color="gray"
+				justify="flex-start"
+				size="sm"
+				variant="outline"
+				leftSection={ <FontAwesomeIcon icon={ faUpload } /> }
+				onClick={ onLoadSet }
+			>
+				{ name }
+			</Button>
+			<Menu position="bottom-end" >
+				<Menu.Target>
+					<ActionIcon variant="subtle" color="gray">
+						<FontAwesomeIcon icon={ faEllipsisVertical } />
+					</ActionIcon>
+				</Menu.Target>
+				<Menu.Dropdown>
+					<Menu.Label>Actions</Menu.Label>
+					<Menu.Item leftSection={ <FontAwesomeIcon icon={ faPen } /> } onClick={ toggleEditing } >Rename</Menu.Item>
+					<Menu.Item color="red" leftSection={ <FontAwesomeIcon icon={ faTrash } /> } onClick={ onDeleteSet } >Delete</Menu.Item>
+				</Menu.Dropdown>
+			</Menu>
 		</Group>
 	);
 });

--- a/src/components/sets/sets.module.css
+++ b/src/components/sets/sets.module.css
@@ -1,4 +1,8 @@
-.setItemName {
+.setItemButton {
+	flex: 1;
+}
+
+.setItemNameInput {
 	flex: 1;
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, Group, Menu, MenuItemProps, Stack, Text } from "@mantine
 import { FunctionComponent, MouseEvent, forwardRef, useCallback } from "react";
 import { useAppDispatch, useAppSelector } from "../hooks/useAppDispatch";
 import { RootStateType } from "../lib/store";
-import { getPatchers } from "../selectors/patchers";
+import { getPatchersSortedByName } from "../selectors/patchers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faObjectGroup, faPlus, faCamera } from "@fortawesome/free-solid-svg-icons";
 import { getConnections, getNodes } from "../selectors/graph";
@@ -41,7 +41,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		connections,
 		presets
 	] = useAppSelector((state: RootStateType) => [
-		getPatchers(state),
+		getPatchersSortedByName(state),
 		getNodes(state),
 		getConnections(state),
 		getGraphSetPrsetsSortedByName(state)

--- a/src/selectors/patchers.ts
+++ b/src/selectors/patchers.ts
@@ -6,6 +6,13 @@ export const getPatchers = (state: RootStateType): ImmuMap<PatcherRecord["id"], 
 	return state.patchers.patchers;
 };
 
+const collator = new Intl.Collator("en-US");
+export const getPatchersSortedByName = (state: RootStateType): ImmuMap<PatcherRecord["id"], PatcherRecord> => {
+	return state.patchers.patchers.sort((pA, pB) => {
+		return collator.compare(pA.name.toLowerCase(), pB.name.toLowerCase());
+	});
+};
+
 export const getPatcher = (state: RootStateType, name: string): PatcherRecord | undefined => {
 	return state.patchers.patchers.get(name);
 };


### PR DESCRIPTION
This PR adds sorting for selection a patcher when creating a new node, offset highlight colors for nodes in the graph and improves the UX for preset and set selection by using buttons as the main CTA and hiding the additional actions in a simple dropdown menu

closes #113 