### PR TITLE
allow for audio to be off

### DIFF
--- a/src/components/page/statusWrapper.tsx
+++ b/src/components/page/statusWrapper.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, PropsWithChildren, ReactNode, memo } from "react";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
-import { faCircleNotch, faPlugCircleXmark } from "@fortawesome/free-solid-svg-icons";
+import { faCircleNotch, faPlugCircleXmark, faVolumeXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useAppSelector } from "../../hooks/useAppDispatch";
 import { RootStateType } from "../../lib/store";
@@ -32,7 +32,6 @@ const AppStatusWrapper: FunctionComponent<PropsWithChildren> = memo(function Wra
 			title = "Initializing State";
 			icon = faCircleNotch;
 			break;
-
 		case AppStatus.Reconnecting:
 			title = "Reconnecting";
 			icon = faCircleNotch;
@@ -44,6 +43,15 @@ const AppStatusWrapper: FunctionComponent<PropsWithChildren> = memo(function Wra
 		case AppStatus.Closed:
 			title = "Connection Lost";
 			icon = faPlugCircleXmark;
+			break;
+		case AppStatus.AudioOff:
+			title = "Audio is Off";
+			icon = faVolumeXmark;
+			helpText = (
+				<>
+					Go to Settings to update audio configuration.
+				</>
+			);
 			break;
 		case AppStatus.Error:
 			title = "Failed to establish Connection";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,6 +11,7 @@ export enum AppStatus {
 	Ready,
 	Reconnecting,
 	ResyncingState,
+	AudioOff,
 	Closed,
 	Error
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -185,11 +185,12 @@ export type OSCQueryRNBOJackState = OSCQueryBaseNode & {
 	CONTENTS: {
 		active: OSCQueryBooleanValue;
 		connections?: OSCQueryRNBOJackConnections,
-		info: OSCQueryBaseNode & {
+		info?: OSCQueryBaseNode & {
 			CONTENTS: {
 				is_realtime: OSCQueryBooleanValue;
 				owns_server: OSCQueryBooleanValue;
 				ports: OSCQueryRNBOJackPortInfo;
+				is_active?: OSCQueryBooleanValue;
 			};
 		};
 		config: OSCQueryRNBOJackConfig;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,7 +184,7 @@ export type OSCQueryRNBOJackTransport =  OSCQueryBaseNode & {
 export type OSCQueryRNBOJackState = OSCQueryBaseNode & {
 	CONTENTS: {
 		active: OSCQueryBooleanValue;
-		connections: OSCQueryRNBOJackConnections,
+		connections?: OSCQueryRNBOJackConnections,
 		info: OSCQueryBaseNode & {
 			CONTENTS: {
 				is_realtime: OSCQueryBooleanValue;
@@ -194,7 +194,7 @@ export type OSCQueryRNBOJackState = OSCQueryBaseNode & {
 		};
 		config: OSCQueryRNBOJackConfig;
 		control: any;
-		transport: OSCQueryRNBOJackTransport;
+		transport?: OSCQueryRNBOJackTransport;
 	};
 };
 


### PR DESCRIPTION
I'm thinking I might make the runner re-send the activated message after the audio actually activates.. the issue is that a user can deactivate audio and then reactivate and we get a `true` sent out before the audio is fully active.. so i have a sleep in there for now.