### PR TITLE
Show Runner info (CPU | xrun)

### DIFF
--- a/src/actions/appStatus.ts
+++ b/src/actions/appStatus.ts
@@ -8,7 +8,8 @@ export enum StatusActionType {
 	SET_STATUS = "SET_STATUS",
 	SET_ENDPOINT = "SET_ENDPOINT",
 	SET_SHOW_ENDPOINT_INFO = "SET_SHOW_ENDPOINT_INFO",
-	INIT_RUNNER_INFO = "INIT_RUNNER_INFO"
+	INIT_RUNNER_INFO = "INIT_RUNNER_INFO",
+	SET_RUNNER_INFO_VALUE = "SET_RUNNER_INFO_VALUE"
 }
 
 export interface ISetAppStatus extends ActionBase {
@@ -41,8 +42,15 @@ export interface IInitRunnerInfo extends ActionBase {
 	};
 }
 
+export interface ISetRunnerInfoValue extends ActionBase {
+	type: StatusActionType.SET_RUNNER_INFO_VALUE;
+	payload: {
+		record: RunnerInfoRecord;
+	};
+}
 
-export type StatusAction = ISetAppStatus | ISetEndpoint | ISetShowEndpointInfo | IInitRunnerInfo;
+
+export type StatusAction = ISetAppStatus | ISetEndpoint | ISetShowEndpointInfo | IInitRunnerInfo | ISetRunnerInfoValue
 
 export const setAppStatus = (status: AppStatus, error?: Error): StatusAction => {
 	return {
@@ -106,3 +114,16 @@ export const initRunnerInfo = (desc: OSCQueryRNBOState): StatusAction => {
 		}
 	};
 };
+
+export const setRunnerInfoValue = (key: RunnerInfoKey, value: RunnerInfoRecord["oscValue"]): AppThunk =>
+	(dispatch, getState) => {
+		const state = getState();
+		const record = state.appStatus.runnerInfo.get(key);
+		if (!record) return;
+		dispatch({
+			type: StatusActionType.SET_RUNNER_INFO_VALUE,
+			payload: {
+				record: record.setValue(value)
+			}
+		});
+	};

--- a/src/actions/appStatus.ts
+++ b/src/actions/appStatus.ts
@@ -1,11 +1,14 @@
 import { AppStatus } from "../lib/constants";
 import { ActionBase, AppThunk } from "../lib/store";
+import { OSCQueryRNBOState } from "../lib/types";
+import { RunnerInfoKey, RunnerInfoRecord } from "../models/runnerInfo";
 import { getShowEndpointInfoModal } from "../selectors/appStatus";
 
 export enum StatusActionType {
 	SET_STATUS = "SET_STATUS",
 	SET_ENDPOINT = "SET_ENDPOINT",
-	SET_SHOW_ENDPOINT_INFO = "SET_SHOW_ENDPOINT_INFO"
+	SET_SHOW_ENDPOINT_INFO = "SET_SHOW_ENDPOINT_INFO",
+	INIT_RUNNER_INFO = "INIT_RUNNER_INFO"
 }
 
 export interface ISetAppStatus extends ActionBase {
@@ -31,8 +34,15 @@ export interface ISetShowEndpointInfo extends ActionBase {
 	};
 }
 
+export interface IInitRunnerInfo extends ActionBase {
+	type: StatusActionType.INIT_RUNNER_INFO;
+	payload: {
+		records: RunnerInfoRecord[];
+	};
+}
 
-export type StatusAction = ISetAppStatus | ISetEndpoint | ISetShowEndpointInfo;
+
+export type StatusAction = ISetAppStatus | ISetEndpoint | ISetShowEndpointInfo | IInitRunnerInfo;
 
 export const setAppStatus = (status: AppStatus, error?: Error): StatusAction => {
 	return {
@@ -79,3 +89,20 @@ export const toggleEndpointInfo = () : AppThunk =>
 		dispatch({ type: StatusActionType.SET_SHOW_ENDPOINT_INFO, payload: { show: !isShown } });
 	};
 
+
+export const initRunnerInfo = (desc: OSCQueryRNBOState): StatusAction => {
+	const jackInfoKeys = [RunnerInfoKey.CPULoad, RunnerInfoKey.XRunCount];
+	const records: RunnerInfoRecord[] = [];
+
+	for (const key of jackInfoKeys) {
+		const jackInfo = desc?.CONTENTS?.jack?.CONTENTS?.info?.CONTENTS?.[key];
+		if (!jackInfo) continue;
+		records.push(RunnerInfoRecord.fromDescription(key, jackInfo));
+	}
+	return {
+		type: StatusActionType.INIT_RUNNER_INFO,
+		payload: {
+			records
+		}
+	};
+};

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -56,7 +56,7 @@ export const Header: FunctionComponent<HeaderProps> = memo(function WrappedHeade
 						</ActionIcon>
 					</Tooltip>
 					<Tooltip label={ `${Math.round(cpuLoad?.oscValue as number || 0)}% CPU Usage`}>
-						<Progress value={ cpuLoad?.oscValue as number || 0 } w={ 28 } size="xl" radius="xs" />
+						<Progress value={ cpuLoad?.oscValue as number || 0 } w={ 25 } size="lg" radius="xs" />
 					</Tooltip>
 				</Group>
 			</Group>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, memo, useCallback } from "react";
-import { ActionIcon, AppShell, Burger, Group, Tooltip } from "@mantine/core";
+import { ActionIcon, AppShell, Burger, Group, Progress, Tooltip } from "@mantine/core";
 import classes from "./header.module.css";
 import { useThemeColorScheme } from "../../hooks/useTheme";
 import { faPlay, faSatelliteDish } from "@fortawesome/free-solid-svg-icons";
@@ -9,6 +9,8 @@ import { toggleEndpointInfo } from "../../actions/appStatus";
 import { toggleTransportControl } from "../../actions/transport";
 import { getTransportControlState } from "../../selectors/transport";
 import { RootStateType } from "../../lib/store";
+import { getRunnerInfoRecord } from "../../selectors/appStatus";
+import { RunnerInfoKey } from "../../models/runnerInfo";
 
 export type HeaderProps = {
 	navOpen: boolean;
@@ -24,9 +26,11 @@ export const Header: FunctionComponent<HeaderProps> = memo(function WrappedHeade
 	const dispatch = useAppDispatch();
 
 	const [
-		isRolling
+		isRolling,
+		cpuLoad
 	] = useAppSelector((state: RootStateType) => [
-		getTransportControlState(state).rolling
+		getTransportControlState(state).rolling,
+		getRunnerInfoRecord(state, RunnerInfoKey.CPULoad)
 	]);
 
 
@@ -46,10 +50,13 @@ export const Header: FunctionComponent<HeaderProps> = memo(function WrappedHeade
 							<FontAwesomeIcon icon={ faPlay } />
 						</ActionIcon>
 					</Tooltip>
-					<Tooltip label="Connection Info" >
+					<Tooltip label="Runner Info" >
 						<ActionIcon variant="transparent" color="gray" onClick={ onToggleEndpointInfo } >
 							<FontAwesomeIcon icon={ faSatelliteDish } />
 						</ActionIcon>
+					</Tooltip>
+					<Tooltip label={ `${Math.round(cpuLoad?.oscValue as number || 0)}% CPU Usage`}>
+						<Progress value={ cpuLoad?.oscValue as number || 0 } w={ 28 } size="xl" radius="xs" />
 					</Tooltip>
 				</Group>
 			</Group>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -9,8 +9,9 @@ import { toggleEndpointInfo } from "../../actions/appStatus";
 import { toggleTransportControl } from "../../actions/transport";
 import { getTransportControlState } from "../../selectors/transport";
 import { RootStateType } from "../../lib/store";
-import { getRunnerInfoRecord } from "../../selectors/appStatus";
+import { getAppStatus, getRunnerInfoRecord } from "../../selectors/appStatus";
 import { RunnerInfoKey } from "../../models/runnerInfo";
+import { AppStatus } from "../../lib/constants";
 
 export type HeaderProps = {
 	navOpen: boolean;
@@ -28,10 +29,13 @@ export const Header: FunctionComponent<HeaderProps> = memo(function WrappedHeade
 	const [
 		isRolling,
 		cpuLoad
-	] = useAppSelector((state: RootStateType) => [
-		getTransportControlState(state).rolling,
-		getRunnerInfoRecord(state, RunnerInfoKey.CPULoad)
-	]);
+	] = useAppSelector((state: RootStateType) => {
+		const status = getAppStatus(state);
+		return [
+			getTransportControlState(state).rolling,
+			status === AppStatus.Ready ? getRunnerInfoRecord(state, RunnerInfoKey.CPULoad) : null
+		];
+	});
 
 
 	const onToggleEndpointInfo = useCallback(() => dispatch(toggleEndpointInfo()), [dispatch]);

--- a/src/components/page/statusWrapper.tsx
+++ b/src/components/page/statusWrapper.tsx
@@ -1,11 +1,13 @@
-import { FunctionComponent, PropsWithChildren, ReactNode, memo } from "react";
+import { FunctionComponent, PropsWithChildren, ReactNode, memo, useCallback } from "react";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { faCircleNotch, faPlugCircleXmark, faVolumeXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useAppSelector } from "../../hooks/useAppDispatch";
+import { useAppSelector, useAppDispatch } from "../../hooks/useAppDispatch";
 import { RootStateType } from "../../lib/store";
 import { getAppStatus } from "../../selectors/appStatus";
 import { AppStatus } from "../../lib/constants";
+import { Anchor } from "@mantine/core";
+import { showSettings } from "../../actions/settings";
 
 import classes from "./page.module.css";
 
@@ -14,6 +16,11 @@ const AppStatusWrapper: FunctionComponent<PropsWithChildren> = memo(function Wra
 }) {
 
 	const status = useAppSelector((state: RootStateType) => getAppStatus(state));
+	const dispatch = useAppDispatch();
+
+	const openSettings = useCallback(() => {
+		dispatch(showSettings());
+	}, [dispatch]);
 
 	let icon: IconDefinition;
 	let title: string;
@@ -49,7 +56,7 @@ const AppStatusWrapper: FunctionComponent<PropsWithChildren> = memo(function Wra
 			icon = faVolumeXmark;
 			helpText = (
 				<>
-					Go to Settings to update audio configuration.
+					Go to <Anchor inherit onClick={ openSettings } >Settings</Anchor> to update audio configuration.
 				</>
 			);
 			break;

--- a/src/controller/oscqueryBridgeController.ts
+++ b/src/controller/oscqueryBridgeController.ts
@@ -1,6 +1,6 @@
 import { parse as parseQuery } from "querystring";
 import { OSCBundle, OSCMessage, readPacket, writePacket } from "osc";
-import { setAppStatus, setConnectionEndpoint } from "../actions/appStatus";
+import { initRunnerInfo, setAppStatus, setConnectionEndpoint } from "../actions/appStatus";
 import { AppDispatch, store } from "../lib/store";
 import { ReconnectingWebsocket } from "../lib/reconnectingWs";
 import { AppStatus, RunnerCmdMethod } from "../lib/constants";
@@ -222,6 +222,8 @@ export class OSCQueryBridgeControllerPrivate {
 		// Init Config
 		dispatch(initRunnerConfig(state));
 
+		// Init Status
+		dispatch(initRunnerInfo(state));
 
 		// Init Patcher Info
 		dispatch(initPatchers(state.CONTENTS.patchers));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -191,6 +191,8 @@ export type OSCQueryRNBOJackState = OSCQueryBaseNode & {
 				owns_server: OSCQueryBooleanValue;
 				ports: OSCQueryRNBOJackPortInfo;
 				is_active?: OSCQueryBooleanValue;
+				xrun_count: OSCQueryIntValue;
+				cpu_load: OSCQueryFloatValue;
 			};
 		};
 		config: OSCQueryRNBOJackConfig;

--- a/src/models/runnerInfo.ts
+++ b/src/models/runnerInfo.ts
@@ -1,5 +1,5 @@
 import { Record as ImmuRecord} from "immutable";
-import { OSCQueryBooleanValue, OSCQueryFloatValue, OSCQueryIntValue, OSCQuerySingleValue, OSCQueryStringValue, OSCQueryValueType } from "../lib/types";
+import { OSCQueryBooleanValue, OSCQueryFloatValue, OSCQueryIntValue, OSCQueryStringValue, OSCQueryValueType } from "../lib/types";
 
 export enum RunnerInfoKey {
 	CPULoad = "cpu_load",

--- a/src/models/runnerInfo.ts
+++ b/src/models/runnerInfo.ts
@@ -6,7 +6,7 @@ export enum RunnerInfoKey {
 	XRunCount = "xrun_count"
 }
 
-export type JackInfoRecordProps = {
+export type RunnerInfoRecordProps = {
 	id: RunnerInfoKey;
 	description: string;
 	oscValue: number | string | boolean | null;
@@ -16,7 +16,7 @@ export type JackInfoRecordProps = {
 
 type RunnierInfoOSCDescType = OSCQueryStringValue | OSCQueryIntValue | OSCQueryBooleanValue | OSCQueryFloatValue;
 
-export class RunnerInfoRecord extends ImmuRecord<JackInfoRecordProps>({
+export class RunnerInfoRecord extends ImmuRecord<RunnerInfoRecordProps>({
 	id: RunnerInfoKey.CPULoad,
 	description: "",
 	oscValue: 0,
@@ -24,6 +24,10 @@ export class RunnerInfoRecord extends ImmuRecord<JackInfoRecordProps>({
 	path: ""
 
 }) {
+
+	public setValue(value: RunnerInfoRecordProps["oscValue"]): RunnerInfoRecord {
+		return this.set("oscValue", value);
+	}
 
 	public static fromDescription(id: RunnerInfoKey, desc: RunnierInfoOSCDescType): RunnerInfoRecord {
 		return new RunnerInfoRecord({

--- a/src/models/runnerInfo.ts
+++ b/src/models/runnerInfo.ts
@@ -1,0 +1,38 @@
+import { Record as ImmuRecord} from "immutable";
+import { OSCQueryBooleanValue, OSCQueryFloatValue, OSCQueryIntValue, OSCQuerySingleValue, OSCQueryStringValue, OSCQueryValueType } from "../lib/types";
+
+export enum RunnerInfoKey {
+	CPULoad = "cpu_load",
+	XRunCount = "xrun_count"
+}
+
+export type JackInfoRecordProps = {
+	id: RunnerInfoKey;
+	description: string;
+	oscValue: number | string | boolean | null;
+	oscType: OSCQueryValueType.String | OSCQueryValueType.True | OSCQueryValueType.False | OSCQueryValueType.Int32 | OSCQueryValueType.Float32 | OSCQueryValueType.Double64;
+	path: string;
+}
+
+type RunnierInfoOSCDescType = OSCQueryStringValue | OSCQueryIntValue | OSCQueryBooleanValue | OSCQueryFloatValue;
+
+export class RunnerInfoRecord extends ImmuRecord<JackInfoRecordProps>({
+	id: RunnerInfoKey.CPULoad,
+	description: "",
+	oscValue: 0,
+	oscType: OSCQueryValueType.Int32,
+	path: ""
+
+}) {
+
+	public static fromDescription(id: RunnerInfoKey, desc: RunnierInfoOSCDescType): RunnerInfoRecord {
+		return new RunnerInfoRecord({
+			id,
+			description: desc.DESCRIPTION || "",
+			oscType: desc.TYPE,
+			oscValue: desc.VALUE,
+			path: desc.FULL_PATH || ""
+		});
+	}
+
+}

--- a/src/reducers/appStatus.ts
+++ b/src/reducers/appStatus.ts
@@ -1,11 +1,14 @@
+import { Map as ImmuMap } from "immutable";
 import { StatusAction, StatusActionType } from "../actions/appStatus";
 import { AppStatus } from "../lib/constants";
+import { RunnerInfoRecord } from "../models/runnerInfo";
 
 export interface AppStatusState {
 	status: AppStatus,
 	error: Error | undefined;
 	endpoint: { hostname: string; port: string; };
 	showEndpointInfo: boolean;
+	runnerInfo: ImmuMap<RunnerInfoRecord["id"], RunnerInfoRecord>;
 }
 
 export const appStatus = (state: AppStatusState = {
@@ -13,7 +16,8 @@ export const appStatus = (state: AppStatusState = {
 	error: undefined,
 	status: AppStatus.Connecting,
 	endpoint: { hostname: "", port: "" },
-	showEndpointInfo: false
+	showEndpointInfo: false,
+	runnerInfo: ImmuMap<RunnerInfoRecord["id"], RunnerInfoRecord>()
 
 }, action: StatusAction): AppStatusState => {
 
@@ -41,6 +45,18 @@ export const appStatus = (state: AppStatusState = {
 			return {
 				...state,
 				showEndpointInfo: show
+			};
+		}
+
+		case StatusActionType.INIT_RUNNER_INFO: {
+			const { records } = action.payload;
+			return {
+				...state,
+				runnerInfo: ImmuMap<RunnerInfoRecord["id"], RunnerInfoRecord>().withMutations(m => {
+					for (const r of records) {
+						m.set(r.id, r);
+					}
+				})
 			};
 		}
 

--- a/src/reducers/appStatus.ts
+++ b/src/reducers/appStatus.ts
@@ -60,6 +60,14 @@ export const appStatus = (state: AppStatusState = {
 			};
 		}
 
+		case StatusActionType.SET_RUNNER_INFO_VALUE : {
+			const { record } = action.payload;
+			return {
+				...state,
+				runnerInfo: state.runnerInfo.set(record.id, record)
+			};
+		}
+
 		default:
 			return state;
 	}

--- a/src/selectors/appStatus.ts
+++ b/src/selectors/appStatus.ts
@@ -1,8 +1,11 @@
 import { AppStatus } from "../lib/constants";
 import { RootStateType } from "../lib/store";
+import { RunnerInfoKey, RunnerInfoRecord } from "../models/runnerInfo";
 
 export const getAppStatus = (state: RootStateType): AppStatus => state.appStatus.status;
 export const getAppStatusError = (state: RootStateType): Error | undefined => state.appStatus.error;
 
 export const getShowEndpointInfoModal = (state: RootStateType): boolean => state.appStatus.showEndpointInfo;
 export const getRunnerEndpoint = (state: RootStateType): { hostname: string; port: string; } => state.appStatus.endpoint;
+
+export const getRunnerInfoRecord = (state: RootStateType, key: RunnerInfoKey): RunnerInfoRecord => state.appStatus.runnerInfo.get(key);


### PR DESCRIPTION
First pass at including some display only info. Drilled open the connection modal and added a CPU meter to the header. Noticed that there isn't a dynamic stream of CPU load info incoming, maybe that's by the design and the frontend / client is supposed to poll that?

Let me know if you need help plumbing this together :D If the client should poll the cpu load it's not really a big deal and we could also add a user setting to enable / disable that.

closes #116