### PR TITLE
simply position nodes without meta at 0, 0

### DIFF
--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -378,12 +378,8 @@ export const initNodes = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 			const info = value as OSCQueryRNBOInstance;
 			let node = GraphPatcherNodeRecord.fromDescription(info);
 			const nodeMeta = meta.nodes[node.id];
-			if (nodeMeta) {
-				node = node.updatePosition(nodeMeta.position.x, nodeMeta.position.y);
-			} else {
-				const { x, y } = getPatcherOrControlNodeCoordinates(node, patcherAndControlNodes);
-				node = node.updatePosition(x, y);
-			}
+			const { x, y } = nodeMeta?.position || { x: 0, y: 0 };
+			node = node.updatePosition(x, y);
 
 			patcherAndControlNodes.push(node);
 			instances.push(InstanceStateRecord.fromDescription(info));
@@ -898,16 +894,13 @@ export const updateSourcePortConnections = (source: string, sinks: string[]): Ap
 	};
 
 export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): AppThunk =>
-	(dispatch, getState) => {
-		const state = getState();
-		const existingNodes = getNodes(state).valueSeq().toArray();
-
+	(dispatch) => {
 		// Create Node
 		let node = GraphPatcherNodeRecord.fromDescription(desc);
 		const setMeta: OSCQuerySetMeta = deserializeSetMeta(metaString);
 		const nodeMeta: OSCQuerySetNodeMeta | undefined = setMeta?.nodes?.[node.id];
 
-		const { x, y } = nodeMeta?.position || getPatcherOrControlNodeCoordinates(node, existingNodes);
+		const { x, y } = nodeMeta?.position || { x: 0, y: 0 }; // default to 0, 0
 		node = node.updatePosition(x, y);
 
 		dispatch(setNode(node));


### PR DESCRIPTION
closes #119 

one issue is that when we clear the graph or delete a node, we don't clear out the meta for that/those nodes.. but, we do once we move a node so I figure in practice that shouldn't get in the way too often... hooking up the logic to transmit the meta after a node pops up felt a little brittle.