### PR TITLE
fix regex for port numbers > 9

### DIFF
--- a/src/components/editor/port.tsx
+++ b/src/components/editor/port.tsx
@@ -29,7 +29,7 @@ const EditorPort: FunctionComponent<PortProps> = memo(function WrappedPort({
 			id={ port.id }
 			position={ handlePositionByPortDirection[port.direction] }
 			data-c74-type={ port.type }
-			data-c74-name={ (alias || port.id.replace(/\((capture|playback)_[0-9+]\)/, "")) }
+			data-c74-name={ (alias || port.id.replace(/\((capture|playback)_[0-9]+\)/, "")) }
 			type={ handleTypeByPortDirection[port.direction] }
 			style={{ top: `${offset}%` }}
 		/>


### PR DESCRIPTION
I goofed on the regex with the last commit. This should apply the substitution for all capture/playback port numbers, not just 0-9