### PR TITLE
graph editor: limit port label size and added on hover styles

### DIFF
--- a/src/components/editor/controlNode.tsx
+++ b/src/components/editor/controlNode.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, memo } from "react";
-import { EditorNodeProps, calcPortOffset } from "./util";
+import { EditorNodeProps, calcPortOffset, defaultNodeWidth } from "./util";
 import { GraphPortRecord, PortDirection } from "../../models/graph";
 import EditorPort from "./port";
 import classes from "./editor.module.css";
@@ -16,17 +16,33 @@ const EditorControlNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		return result;
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
+	const portSizeLimit = sinks.length && sources.length ? Math.round(defaultNodeWidth / 2) : defaultNodeWidth;
+
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.id }
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px` }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: defaultNodeWidth }} >
 				{
-					sinks.map((port, i) => <EditorPort key={ port.id } port={ port } offset={ calcPortOffset(sinks.length, i)}/>)
+					sinks.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sinks.length, i)}
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 				{
-					sources.map((port, i) => <EditorPort key={ port.id } port={ port } offset={ calcPortOffset(sources.length, i) } />)
+					sources.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sources.length, i) }
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 			</div>
 		</Paper>

--- a/src/components/editor/editor.module.css
+++ b/src/components/editor/editor.module.css
@@ -129,7 +129,6 @@
 			&:after {
 				background-clip: padding-box;
 				border-radius: var(--mantine-radius-sm);
-				direction: rtl;
 				font-size: var(--mantine-font-size-sm);
 				max-width: calc(var(--label-max-width) - var(--label-offset));
 				overflow: hidden;
@@ -159,8 +158,8 @@
 
 			&:before {
 				content: attr(data-c74-name);
-				margin-right: var(--label-offset);
-				right: 0;
+				direction: rtl;
+				right: var(--label-offset);
 			}
 		}
 
@@ -170,24 +169,7 @@
 
 			&:after {
 				content: attr(data-c74-name);
-				margin-left: var(--label-offset);
-				left: 0;
-			}
-		}
-
-		.react-flow__handle[data-c74-type="audio"] {
-			border: 2px solid var(--mantine-color-green-outline);
-
-			&:hover {
-				background-color: var(--mantine-color-green-outline);
-			}
-		}
-
-		.react-flow__handle[data-c74-type="midi"] {
-			border: 2px solid var(--mantine-color-orange-outline);
-
-			&:hover {
-				background-color: var(--mantine-color-orange-outline);
+				left: var(--label-offset);
 			}
 		}
 	}

--- a/src/components/editor/editor.module.css
+++ b/src/components/editor/editor.module.css
@@ -34,33 +34,29 @@
 	flex: 1;
 
 	&[data-color-scheme="light"] {
-		.node {
-			background-color: var(--mantine-color-default-hover);
-			border-color: var(--mantine-color-gray-4);
 
-			&[data-selected="true"] {
-				border-color: var(--mantine-primary-color-filled);
-			}
-		}
-
-		.nodeHeader {
-			color: var(--mantine-color-default-color);
-		}
+		--node-background-color: var(--mantine-color-default-hover);
+		--node-border-color: var(--mantine-color-gray-4);
+		--node-border-color-selected: var(--mantine-primary-color-filled);
 	}
 
 	&[data-color-scheme="dark"] {
-		.node {
-			background-color: var(--mantine-color-default);
-			border-color: var(--mantine-color-gray-7);
+		--node-background-color: var(--mantine-color-default);
+		--node-border-color: var(--mantine-color-gray-7);
+		--node-border-color-selected: var(--mantine-primary-color-filled);
+	}
 
-			&[data-selected="true"] {
-				border-color: var(--mantine-primary-color-filled);
-			}
-		}
+	.node {
+		background-color: var(--node-background-color);
+		border-color: var(--node-border-color);
 
-		.nodeHeader {
-			color: var(--mantine-color-default-color);
+		&[data-selected="true"] {
+			border-color: var(--node-border-color-selected);
 		}
+	}
+
+	.nodeHeader {
+		color: var(--mantine-color-default-color);
 	}
 
 	:global {
@@ -105,9 +101,25 @@
 		}
 
 		.react-flow__handle {
+
+			--label-offset: 24px;
+
+			&[data-c74-type="audio"] {
+				--handle-color: var(--mantine-color-green-outline);
+			}
+
+			&[data-c74-type="midi"] {
+				--handle-color: var(--mantine-color-orange-outline);
+			}
+
+			border: 2px solid var(--handle-color);
 			border-radius: 50%;
 			height: 20px;
 			width: 20px;
+
+			&:hover {
+				background-color: var(--handle-color);
+			}
 		}
 
 		.react-flow__handle-right,
@@ -115,11 +127,28 @@
 
 			&:before,
 			&:after {
+				background-clip: padding-box;
+				border-radius: var(--mantine-radius-sm);
+				direction: rtl;
 				font-size: var(--mantine-font-size-sm);
+				max-width: calc(var(--label-max-width) - var(--label-offset));
 				overflow: hidden;
+				padding: 0px 4px;
 				position: absolute;
 				text-overflow: ellipsis;
 				transform: translateY(-20%);
+				white-space: nowrap;
+			}
+
+			&:hover {
+
+				&:before,
+				&:after {
+					background-color: var(--node-background-color);
+					box-shadow: var(--mantine-shadow-xs);
+					max-width: fit-content;
+					z-index: 50;
+				}
 			}
 		}
 
@@ -130,9 +159,8 @@
 
 			&:before {
 				content: attr(data-c74-name);
-				padding-right: 25px;
+				margin-right: var(--label-offset);
 				right: 0;
-				white-space: nowrap;
 			}
 		}
 
@@ -142,9 +170,8 @@
 
 			&:after {
 				content: attr(data-c74-name);
-				padding-left: 25px;
+				margin-left: var(--label-offset);
 				left: 0;
-				white-space: nowrap;
 			}
 		}
 

--- a/src/components/editor/editor.module.css
+++ b/src/components/editor/editor.module.css
@@ -141,12 +141,13 @@
 
 			&:hover {
 
+				z-index: 50000;
+
 				&:before,
 				&:after {
 					background-color: var(--node-background-color);
 					box-shadow: var(--mantine-shadow-xs);
 					max-width: fit-content;
-					z-index: 50;
 				}
 			}
 		}

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -21,6 +21,8 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		return result;
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
+	const portSizeLimit = sinks.length && sources.length ? Math.round(300 / 2) : 300;
+
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
@@ -40,12 +42,26 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 					</Tooltip>
 				</div>
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px` }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: 300 }} >
 				{
-					sinks.map((port, i) => <EditorPort key={ port.id } port={ port } offset={ calcPortOffset(sinks.length, i)}/>)
+					sinks.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sinks.length, i)}
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 				{
-					sources.map((port, i) => <EditorPort key={ port.id } port={ port } offset={ calcPortOffset(sources.length, i) } />)
+					sources.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sources.length, i) }
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 			</div>
 		</Paper>

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, memo } from "react";
-import { EditorNodeProps, calcPortOffset } from "./util";
+import { EditorNodeProps, calcPortOffset, defaultNodeWidth } from "./util";
 import { GraphPatcherNodeRecord, GraphPortRecord, PortDirection } from "../../models/graph";
 import EditorPort from "./port";
 import classes from "./editor.module.css";
@@ -21,7 +21,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		return result;
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
-	const portSizeLimit = sinks.length && sources.length ? Math.round(300 / 2) : 300;
+	const portSizeLimit = sinks.length && sources.length ? Math.round(defaultNodeWidth / 2) : defaultNodeWidth;
 
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
@@ -42,7 +42,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 					</Tooltip>
 				</div>
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: 300 }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: defaultNodeWidth }} >
 				{
 					sinks.map((port, i) => (
 						<EditorPort

--- a/src/components/editor/port.tsx
+++ b/src/components/editor/port.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, memo } from "react";
+import React, { CSSProperties, FunctionComponent, memo } from "react";
 import { GraphPortRecord, PortDirection } from "../../models/graph";
 import { Handle, HandleType, Position } from "reactflow";
 
@@ -6,6 +6,7 @@ export type PortProps = {
 	offset: number;
 	alias?: string;
 	port: GraphPortRecord;
+	maxWidth: number;
 };
 
 const handleTypeByPortDirection: Record<PortDirection, HandleType> = {
@@ -20,6 +21,7 @@ const handlePositionByPortDirection: Record<PortDirection, Position> = {
 
 const EditorPort: FunctionComponent<PortProps> = memo(function WrappedPort({
 	port,
+	maxWidth,
 	alias,
 	offset
 }) {
@@ -31,7 +33,7 @@ const EditorPort: FunctionComponent<PortProps> = memo(function WrappedPort({
 			data-c74-type={ port.type }
 			data-c74-name={ (alias || port.id.replace(/\((capture|playback)_[0-9]+\)/, "")) }
 			type={ handleTypeByPortDirection[port.direction] }
-			style={{ top: `${offset}%` }}
+			style={{ top: `${offset}%`, "--label-max-width": `${maxWidth}px` } as CSSProperties }
 		/>
 	);
 });

--- a/src/components/editor/systemNode.tsx
+++ b/src/components/editor/systemNode.tsx
@@ -25,17 +25,36 @@ const EditorSystemNode: FunctionComponent<EditorNodeProps> = memo(function Wrapp
 		return alias.length > result ? alias.length : result;
 	}, 0);
 
+	const width = 300 + Math.max(0, (longestAliasCharCount - 10) * 5);
+	const portSizeLimit = sinks.length && sources.length ? Math.round(width / 2) : width;
+
 	return (
 		<Paper className={ classes.node }  shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.jackName }
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: `${300 + Math.max(0, (longestAliasCharCount - 10) * 5)}px` }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: `${width}px` }} >
 				{
-					sinks.map((port, i) => <EditorPort key={ port.id }  port={ port } offset={ calcPortOffset(sinks.length, i) } alias={ aliases.get(port.portName) } />)
+					sinks.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sinks.length, i) }
+							alias={ aliases.get(port.portName) }
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 				{
-					sources.map((port, i) => <EditorPort key={ port.id } port={ port } offset={ calcPortOffset(sources.length, i) } alias={ aliases.get(port.portName) } />)
+					sources.map((port, i) => (
+						<EditorPort
+							key={ port.id }
+							port={ port }
+							offset={ calcPortOffset(sources.length, i) }
+							alias={ aliases.get(port.portName) }
+							maxWidth={ portSizeLimit }
+						/>
+					))
 				}
 			</div>
 		</Paper>

--- a/src/components/editor/util.ts
+++ b/src/components/editor/util.ts
@@ -16,3 +16,5 @@ export type EditorEdgeProps = EdgeProps<EdgeDataProps>;
 export const calcPortOffset = (total: number, index: number): number => {
 	return (index + 1) * (1 / (total + 1)) * 100;
 };
+
+export const defaultNodeWidth = 300;


### PR DESCRIPTION
Added styles and code to deal with long port names by clipping the label with an ellipsis and adding hover highlighting styles
See example screenshots attached

closes #173 

<img width="710" alt="Screenshot 2024-12-11 at 15 39 00" src="https://github.com/user-attachments/assets/3677294d-febc-4bab-a312-ccb8707e2b08" />
ee ex
<img width="941" alt="Screenshot 2024-12-11 at 15 39 04" src="https://github.com/user-attachments/assets/93503841-0fa6-4c14-8d4a-cd90f75e2344" />

<img width="970" alt="Screenshot 2024-12-11 at 15 38 33" src="https://github.com/user-attachments/assets/5b7dfd89-5ea7-4b29-b7fd-0048deb92916" />
