### PR TITLE
Patcher Node placement & Auto Layouting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rnbo-runner-panel",
       "version": "2.1.1-beta.0",
       "dependencies": {
+        "@dagrejs/dagre": "^1.1.4",
         "@mantine/core": "^7.10.2",
         "@mantine/dropzone": "^7.10.2",
         "@mantine/hooks": "^7.10.2",
@@ -68,6 +69,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.4.tgz",
+      "integrity": "sha512-QUTc54Cg/wvmlEUxB+uvoPVKFazM1H18kVHBQNmK2NbrDR5ihOCR6CXLnDSZzMcSQKJtabPUWridBOlJM3WkDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preversion": "next lint"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
     "@mantine/core": "^7.10.2",
     "@mantine/dropzone": "^7.10.2",
     "@mantine/hooks": "^7.10.2",

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -1,9 +1,22 @@
-import { ReactFlowInstance } from "reactflow";
-import { ActionBase } from "../lib/store";
+import { Connection, EdgeChange, NodeChange, ReactFlowInstance } from "reactflow";
+import { Map as ImmuMap } from "immutable";
+import { ActionBase, AppThunk } from "../lib/store";
+import { getConnection, getConnectionByNodesAndPorts, getNode, getNodes } from "../selectors/graph";
+import { GraphConnectionRecord, GraphNode, GraphNodeRecord, GraphPatcherNode, NodeType } from "../models/graph";
+import { showNotification } from "./notifications";
+import { NotificationLevel } from "../models/notification";
+import { writePacket } from "osc";
+import { oscQueryBridge } from "../controller/oscqueryBridgeController";
+import { isValidConnection } from "../lib/editorUtils";
+import throttle from "lodash.throttle";
+import { OSCQuerySetMeta } from "../lib/types";
+import { setConnection, setNode, unloadPatcherNodeByIndexOnRemote } from "./graph";
+import { getGraphEditorInstance, getGraphEditorLockedState } from "../selectors/editor";
 
 export enum EditorActionType {
 	INIT = "EDITOR_INIT",
-	UNMOUNT = "EDITOR_UNMOUNT"
+	UNMOUNT = "EDITOR_UNMOUNT",
+	SET_LOCKED = "EDITOR_SET_LOCKED"
 }
 
 export interface IInitEditor extends ActionBase {
@@ -15,10 +28,17 @@ export interface IInitEditor extends ActionBase {
 
 export interface IUnmountEditor extends ActionBase {
 	type: EditorActionType.UNMOUNT;
-	payload: {};
+	payload: Record<string, never>;
 }
 
-export type EditorAction = IInitEditor | IUnmountEditor;
+export interface ISetEditorLocked extends ActionBase {
+	type: EditorActionType.SET_LOCKED;
+	payload: {
+		locked: boolean;
+	};
+}
+
+export type EditorAction = IInitEditor | IUnmountEditor | ISetEditorLocked;
 
 export const initEditor = (instance: ReactFlowInstance): IInitEditor => {
 	return {
@@ -33,3 +53,275 @@ export const unmountEditor = (): IUnmountEditor => {
 		payload: {}
 	};
 };
+
+
+const serializeSetMeta = (nodes: GraphNodeRecord[]): string => {
+	const result: OSCQuerySetMeta = { nodes: {} };
+	for (const node of nodes) {
+		result.nodes[node.id] = { position: { x: node.x, y: node.y } };
+	}
+	return JSON.stringify(result);
+};
+
+const doUpdateNodesMeta = throttle((nodes: ImmuMap<GraphNodeRecord["id"], GraphNodeRecord>) => {
+	try {
+		const value = serializeSetMeta(nodes.valueSeq().toArray());
+
+		const message = {
+			address: "/rnbo/inst/control/sets/meta",
+			args: [
+				{ type: "s", value }
+			]
+		};
+		oscQueryBridge.sendPacket(writePacket(message));
+	} catch (err) {
+		console.warn(`Failed to update Set Meta on remote: ${err.message}`);
+	}
+
+}, 150, { leading: true, trailing: true });
+
+const updateSetMetaOnRemote = (): AppThunk =>
+	(dispatch, getState) => doUpdateNodesMeta(getNodes(getState()));
+
+
+export const createEditorConnection = (connection: Connection): AppThunk =>
+	(dispatch, getState) => {
+		try {
+			const state = getState();
+
+			if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) {
+				throw new Error(`Invalid Connection Description (${connection.source}:${connection.sourceHandle} => ${connection.target}:${connection.targetHandle})`);
+			}
+
+			// Valid Connection?
+			const { sourceNode, sourcePort, sinkNode, sinkPort } = isValidConnection(connection, state.graph.nodes);
+
+			// Does it already exist?
+			const existingConnection = getConnectionByNodesAndPorts(
+				state,
+				{
+					sourceNodeId: sourceNode.id,
+					sinkNodeId: sinkNode.id,
+					sourcePortId: sourcePort.id,
+					sinkPortId: sinkPort.id
+				}
+			);
+
+			if (existingConnection) {
+				return void dispatch(showNotification({
+					title: "Skipped creating connection",
+					level: NotificationLevel.warn,
+					message: `A connection between ${connection.source}:${connection.sourceHandle} and ${connection.target}:${connection.targetHandle} already exists`
+				}));
+			}
+
+			const message = {
+				address: "/rnbo/jack/connections/connect",
+				args: [
+					{ type: "s", value: `${sourceNode.jackName}:${sourcePort.id}` },
+					{ type: "s", value: `${sinkNode.jackName}:${sinkPort.id}` }
+				]
+			};
+
+			oscQueryBridge.sendPacket(writePacket(message));
+		} catch (err) {
+			dispatch(showNotification({
+				title: "Failed to create connection",
+				level: NotificationLevel.error,
+				message: err.message
+			}));
+			console.error(err);
+		}
+	};
+
+export const removeEditorConnectionById = (id: GraphConnectionRecord["id"]): AppThunk =>
+	(dispatch, getState) => {
+
+		try {
+			const state = getState();
+			const connection = getConnection(state, id);
+			if (!connection) throw new Error(`Connection with id ${id} does not exist.`);
+
+			const sourceNode = getNode(state, connection.sourceNodeId);
+			if (!sourceNode) throw new Error(`Node with id ${connection.sourceNodeId} does not exist.`);
+
+			const sourcePort = sourceNode.getPort(connection.sourcePortId);
+			if (!sourcePort) throw new Error(`Port with id ${connection.sourcePortId} does not exist on node ${sourceNode.id}.`);
+
+			const sinkNode = getNode(state, connection.sinkNodeId);
+			if (!sinkNode) throw new Error(`Node with id ${connection.sinkNodeId} does not exist.`);
+
+			const sinkPort = sinkNode.getPort(connection.sinkPortId);
+			if (!sinkPort) throw new Error(`Port with id ${connection.sinkPortId} does not exist on node ${sinkNode.id}.`);
+
+			const message = {
+				address: "/rnbo/jack/connections/disconnect",
+				args: [
+					{ type: "s", value: `${sourceNode.jackName}:${sourcePort.id}` },
+					{ type: "s", value: `${sinkNode.jackName}:${sinkPort.id}` }
+				]
+			};
+
+			oscQueryBridge.sendPacket(writePacket(message));
+
+		} catch (err) {
+			dispatch(showNotification({
+				title: "Failed to delete connection",
+				level: NotificationLevel.error,
+				message: err.message
+			}));
+			console.error(err);
+		}
+	};
+
+
+export const removeEditorNodeById = (id: GraphNode["id"], updateSetMeta = true): AppThunk =>
+	(dispatch, getState) => {
+		try {
+			const state = getState();
+			const node = getNode(state, id);
+
+			if (!node) {
+				throw new Error(`Node with id ${id} does not exist.`);
+			}
+
+			if (node.type === NodeType.System || node.type === NodeType.Control) {
+				throw new Error(`System nodes cannot be removed (id: ${id}).`);
+			}
+
+			dispatch(unloadPatcherNodeByIndexOnRemote(node.index));
+			if (updateSetMeta) doUpdateNodesMeta(getNodes(state).delete(node.id));
+
+		} catch (err) {
+			dispatch(showNotification({
+				title: "Failed to node",
+				level: NotificationLevel.error,
+				message: err.message
+			}));
+			console.error(err);
+		}
+	};
+
+export const removeEditorNodesById = (ids: GraphPatcherNode["id"][]): AppThunk =>
+	(dispatch, getState) => {
+		for (const id of ids) {
+			dispatch(removeEditorNodeById(id, false));
+		}
+		// Only at the end update the meta to ensure all coord data has been removed
+		doUpdateNodesMeta(getNodes(getState()).deleteAll(ids));
+	};
+
+export const removeEditorConnectionsById = (ids: GraphConnectionRecord["id"][]): AppThunk =>
+	(dispatch) => {
+		for (const id of ids) {
+			dispatch(removeEditorConnectionById(id));
+		}
+	};
+
+export const changeNodePosition = (id: GraphNode["id"], x: number, y: number): AppThunk =>
+	(dispatch, getState) => {
+		const state = getState();
+		const node = getNode(state, id);
+		if (!node) return;
+		dispatch(setNode(node.updatePosition(x, y)));
+		dispatch(updateSetMetaOnRemote());
+	};
+
+export const changeNodeSelection = (id: GraphNode["id"], selected: boolean): AppThunk =>
+	(dispatch, getState) => {
+		const state = getState();
+		const node = getNode(state, id);
+		if (!node) return;
+		dispatch(setNode(selected ? node.select() : node.unselect()));
+	};
+
+export const changeEdgeSelection = (id: GraphConnectionRecord["id"], selected: boolean): AppThunk =>
+	(dispatch, getState) => {
+		const state = getState();
+		const connection = getConnection(state, id);
+		if (!connection) return;
+		dispatch(setConnection(selected ? connection.select() : connection.unselect()));
+	};
+
+export const applyEditorNodeChanges = (changes: NodeChange[]): AppThunk =>
+	(dispatch) => {
+		for (const change of changes) {
+			switch (change.type) {
+				case "position": {
+					if (change.position) {
+						dispatch(changeNodePosition(
+							change.id,
+							change.position.x,
+							change.position.y
+						));
+					}
+					break;
+				}
+
+				case "select": {
+					dispatch(changeNodeSelection(change.id, change.selected));
+					break;
+				}
+
+				case "remove": // handled separetely via dedicated action
+				case "add":
+				case "reset":
+				case "dimensions":
+				default:
+					// no-op
+			}
+		}
+	};
+
+export const applyEditorEdgeChanges = (changes: EdgeChange[]): AppThunk =>
+	(dispatch) => {
+		for (const change of changes) {
+			switch (change.type) {
+				case "select": {
+					dispatch(changeEdgeSelection(change.id, change.selected));
+					break;
+				}
+
+				case "remove": // handled separetely via dedicated action
+				case "add":
+				case "reset":
+				default:
+					// no-op
+			}
+		}
+	};
+
+export const setEditorLockedState = (state: boolean): ISetEditorLocked => {
+	return {
+		type: EditorActionType.SET_LOCKED,
+		payload: {
+			locked: state
+		}
+	};
+};
+
+export const toggleEditorLockedState = (): AppThunk =>
+	(dispatch, getState) => {
+		const state = getState();
+		dispatch(setEditorLockedState(!getGraphEditorLockedState(state)));
+	};
+
+export const triggerEditorFitView = (): AppThunk =>
+	(_, getState) => {
+		const state = getState();
+		getGraphEditorInstance(state)?.fitView();
+	};
+
+export const editorZoomIn = (): AppThunk =>
+	(_, getState) => {
+		const state = getState();
+		getGraphEditorInstance(state)?.zoomIn();
+	};
+
+export const editorZoomOut = (): AppThunk =>
+	(_, getState) => {
+		const state = getState();
+		getGraphEditorInstance(state)?.zoomOut();
+	};
+
+

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -2,7 +2,7 @@ import Dagre from "@dagrejs/dagre";
 import { Connection, EdgeChange, NodeChange, ReactFlowInstance } from "reactflow";
 import { Map as ImmuMap } from "immutable";
 import { ActionBase, AppThunk } from "../lib/store";
-import { getConnection, getConnectionByNodesAndPorts, getConnections, getControlNodes, getNode, getNodes, getPatcherNodes, getSystemNodes } from "../selectors/graph";
+import { getConnection, getConnectionByNodesAndPorts, getConnections, getNode, getNodes } from "../selectors/graph";
 import { GraphConnectionRecord, GraphNode, GraphNodeRecord, GraphPatcherNode, NodeType } from "../models/graph";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -1,0 +1,35 @@
+import { ReactFlowInstance } from "reactflow";
+import { ActionBase } from "../lib/store";
+
+export enum EditorActionType {
+	INIT = "EDITOR_INIT",
+	UNMOUNT = "EDITOR_UNMOUNT"
+}
+
+export interface IInitEditor extends ActionBase {
+	type: EditorActionType.INIT;
+	payload: {
+		instance: ReactFlowInstance;
+	};
+}
+
+export interface IUnmountEditor extends ActionBase {
+	type: EditorActionType.UNMOUNT;
+	payload: {};
+}
+
+export type EditorAction = IInitEditor | IUnmountEditor;
+
+export const initEditor = (instance: ReactFlowInstance): IInitEditor => {
+	return {
+		type: EditorActionType.INIT,
+		payload: { instance }
+	};
+};
+
+export const unmountEditor = (): IUnmountEditor => {
+	return {
+		type: EditorActionType.UNMOUNT,
+		payload: {}
+	};
+};

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -15,6 +15,7 @@ import { Connection, EdgeChange, NodeChange } from "reactflow";
 import { isValidConnection } from "../lib/editorUtils";
 import throttle from "lodash.throttle";
 import { getPatchers } from "../selectors/patchers";
+import { nodeDefaultWidth, nodeHeaderHeight } from "../lib/constants";
 
 const defaultNodeSpacing = 150;
 const getPatcherOrControlNodeCoordinates = (node: GraphPatcherNodeRecord | GraphControlNodeRecord, nodes: GraphNodeRecord[]): { x: number, y: number } => {
@@ -580,10 +581,12 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 					direction,
 					id: `${jackName}${direction === PortDirection.Source ? GraphSystemNodeRecord.inputSuffix : GraphSystemNodeRecord.outputSuffix}`,
 					ports,
-					contentHeight,
 					selected: false,
 					x: 0,
-					y: 0
+					y: 0,
+					width: nodeDefaultWidth,
+					height: contentHeight + nodeHeaderHeight
+
 				});
 
 				if (direction === PortDirection.Source) {
@@ -605,10 +608,11 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 				node = new GraphControlNodeRecord({
 					jackName,
 					ports,
-					contentHeight,
 					selected: false,
 					x: 0,
-					y: 0
+					y: 0,
+					width: nodeDefaultWidth,
+					height: contentHeight + nodeHeaderHeight
 				});
 				const { x, y } = getPatcherOrControlNodeCoordinates(node, [...patcherNodes, ...controlNodes]);
 				node = node.updatePosition(x, y);
@@ -902,7 +906,7 @@ export const updateSourcePortConnections = (source: string, sinks: string[]): Ap
 	};
 
 export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): AppThunk =>
-	(dispatch) => {
+	(dispatch, getState) => {
 		// Create Node
 		let node = GraphPatcherNodeRecord.fromDescription(desc);
 		const setMeta: OSCQuerySetMeta = deserializeSetMeta(metaString);

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -675,8 +675,8 @@ export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): 
 
 		const state = getState();
 		const { x, y } = nodeMeta?.position || getGraphEditorInstance(state)?.project({
-			y: 10,
-			x: 10
+			y: 0,
+			x: 0
 		}) || getPatcherOrControlNodeCoordinates(node, []);
 
 		node = node.updatePosition(x, y);

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -912,9 +912,13 @@ export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): 
 		const setMeta: OSCQuerySetMeta = deserializeSetMeta(metaString);
 		const nodeMeta: OSCQuerySetNodeMeta | undefined = setMeta?.nodes?.[node.id];
 
-		const { x, y } = nodeMeta?.position || getPatcherOrControlNodeCoordinates(node, []);
-		node = node.updatePosition(x, y);
+		const state = getState();
+		const { x, y } = nodeMeta?.position || state.editor.instance?.project({
+			y: 10,
+			x: 10
+		}) || getPatcherOrControlNodeCoordinates(node, []);
 
+		node = node.updatePosition(x, y);
 		dispatch(setNode(node));
 
 		// Create Instance State

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -12,10 +12,9 @@ import { deleteInstance, setInstance, setInstances } from "./instances";
 import { getInstance } from "../selectors/instances";
 import { PatcherRecord } from "../models/patcher";
 import { getPatchers } from "../selectors/patchers";
-import { nodeDefaultWidth, nodeHeaderHeight } from "../lib/constants";
+import { defaultNodeGap, nodeDefaultWidth, nodeHeaderHeight } from "../lib/constants";
 import { getGraphEditorInstance } from "../selectors/editor";
 
-const defaultNodeSpacing = 150;
 const getPatcherOrControlNodeCoordinates = (node: GraphPatcherNodeRecord | GraphControlNodeRecord, nodes: GraphNodeRecord[]): { x: number, y: number } => {
 
 	let y = 0;
@@ -26,10 +25,10 @@ const getPatcherOrControlNodeCoordinates = (node: GraphPatcherNodeRecord | Graph
 			return current.y > n.y ? current : n;
 		}, undefined as GraphNodeRecord | undefined);
 
-		y = bottomNode ? bottomNode.y + bottomNode.height + defaultNodeSpacing : 0;
+		y = bottomNode ? bottomNode.y + bottomNode.height + defaultNodeGap : 0;
 	}
 
-	return { x: 435 + defaultNodeSpacing, y };
+	return { x: nodeDefaultWidth + defaultNodeGap, y };
 };
 
 const deserializeSetMeta = (metaString: string): OSCQuerySetMeta => {
@@ -385,8 +384,8 @@ export const initNodes = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 		// as we assume moving forward that they are SystemNames
 		const systemJackNames = ImmuSet<string>(getSystemNodeJackNamesFromPortInfo(jackPortsInfo, patcherAndControlNodes));
 
-		let systemInputY = -defaultNodeSpacing;
-		let systemOutputY = -defaultNodeSpacing;
+		let systemInputY = -defaultNodeGap;
+		let systemOutputY = -defaultNodeGap;
 
 		const systemNodes: GraphSystemNodeRecord[] = GraphSystemNodeRecord
 			.fromDescription(systemJackNames, jackPortsInfo)
@@ -400,13 +399,13 @@ export const initNodes = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 				if (node.id.endsWith(GraphSystemNodeRecord.inputSuffix)) {
 					node = node.updatePosition(
 						0,
-						systemInputY + defaultNodeSpacing
+						systemInputY + defaultNodeGap
 					);
 					systemInputY = node.y + node.contentHeight;
 				} else {
 					node = node.updatePosition(
-						node.width + 300 + defaultNodeSpacing * 2,
-						systemOutputY + defaultNodeSpacing
+						node.width + 300 + defaultNodeGap * 2,
+						systemOutputY + defaultNodeGap
 					);
 					systemOutputY = node.y + node.contentHeight;
 				}
@@ -531,8 +530,8 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 		}
 
 		// Create New Nodes
-		let systemInputY = -defaultNodeSpacing;
-		let systemOutputY = -defaultNodeSpacing;
+		let systemInputY = -defaultNodeGap;
+		let systemOutputY = -defaultNodeGap;
 
 		const patchers = getPatchers(state).valueSeq();
 		const missingSystemOrControlJackName = Array.from(systemOrControlJackNames.values())
@@ -562,13 +561,13 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 				if (direction === PortDirection.Source) {
 					node = node.updatePosition(
 						0,
-						systemInputY + defaultNodeSpacing
+						systemInputY + defaultNodeGap
 					);
 					systemInputY = node.y + node.contentHeight;
 				} else {
 					node = node.updatePosition(
-						node.width + 300 + defaultNodeSpacing * 2,
-						systemOutputY + defaultNodeSpacing
+						node.width + 300 + defaultNodeGap * 2,
+						systemOutputY + defaultNodeGap
 					);
 					systemOutputY = node.y + node.contentHeight;
 				}

--- a/src/components/editor/controlNode.tsx
+++ b/src/components/editor/controlNode.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, memo } from "react";
-import { EditorNodeProps, calcPortOffset, defaultNodeWidth } from "./util";
+import { EditorNodeProps, calcPortOffset } from "./util";
 import { GraphPortRecord, PortDirection } from "../../models/graph";
 import EditorPort from "./port";
 import classes from "./editor.module.css";
@@ -16,14 +16,14 @@ const EditorControlNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		return result;
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
-	const portSizeLimit = sinks.length && sources.length ? Math.round(defaultNodeWidth / 2) : defaultNodeWidth;
+	const portSizeLimit = sinks.length && sources.length ? Math.round(node.width / 2) : node.width;
 
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.id }
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: defaultNodeWidth }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px` }} >
 				{
 					sinks.map((port, i) => (
 						<EditorPort

--- a/src/components/editor/editor.module.css
+++ b/src/components/editor/editor.module.css
@@ -30,6 +30,11 @@
 	pointer-events: all;
 }
 
+.controls {
+	position: fixed;
+	bottom: var(--mantine-spacing-md);
+}
+
 .editor {
 	flex: 1;
 
@@ -65,17 +70,6 @@
 			background-color: transparent;
 			a {
 				color: var(--mantine-color-default-color);
-			}
-		}
-
-		.react-flow__controls-button {
-			background: var(--mantine-color-default);
-			border-bottom-color: var(--mantine-color-default-border);
-			box-shadow: var(--mantine-shadow-sm);
-			fill: var(--mantine-color-default-color);
-
-			&:hover {
-				background: var(--mantine-color-default-hover);
 			}
 		}
 

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, FunctionComponent, memo, useCallback } from "react";
-import ReactFlow, { Connection, Controls, Edge, EdgeChange, Node, NodeChange } from "reactflow";
+import ReactFlow, { Connection, Controls, Edge, EdgeChange, Node, NodeChange, ReactFlowInstance } from "reactflow";
 import { GraphConnectionRecord, GraphPatcherNodeRecord, NodeType } from "../../models/graph";
 import EditorPatcherNode from "./patcherNode";
 import EditorSystemNode from "./systemNode";
@@ -17,6 +17,7 @@ import { useMantineColorScheme } from "@mantine/core";
 export type GraphEditorProps = {
 	connections: RootStateType["graph"]["connections"];
 	nodes: RootStateType["graph"]["nodes"];
+	onInit: (instance: ReactFlowInstance) => void;
 	onConnect: (connection: Connection) => any;
 	onNodesDelete: (nodes: Pick<Edge, "id">[]) => void;
 	onNodesChange: (changes: NodeChange[]) => void;
@@ -37,6 +38,7 @@ const edgeTypes: Record<typeof RNBOGraphEdgeType, ComponentType<EditorEdgeProps>
 const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFlowGraph({
 	connections,
 	nodes,
+	onInit,
 	onConnect,
 	onNodesChange,
 	onNodesDelete,
@@ -74,11 +76,9 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 		deletable: node.type === NodeType.Patcher,
 		selected: node.selected,
 		type: node?.type,
-		data: {
-			node
-		}
+		data: { node },
+		style: { height: node.height, width: node.width }
 	}));
-
 
 	const flowEdges: Edge<EdgeDataProps>[] = connections.valueSeq().toArray().map(connection => ({
 		id: connection.id,
@@ -109,6 +109,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 				edgeTypes={ edgeTypes }
 				edgesUpdatable={ false }
 				fitView
+				onInit={ onInit }
 				minZoom={ 0.1 }
 				maxZoom={ 5 }
 			>

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import EditorControlNode from "./controlNode";
 import { ActionIcon, Tooltip, useMantineColorScheme } from "@mantine/core";
 import { IconElement } from "../elements/icon";
-import { mdiFitToScreen, mdiLock, mdiLockOpen, mdiMinus, mdiPlus } from "@mdi/js";
+import { mdiFitToScreen, mdiLock, mdiLockOpen, mdiMinus, mdiPlus, mdiSitemap } from "@mdi/js";
 import { maxEditorZoom, minEditorZoom } from "../../lib/constants";
 
 export type GraphEditorProps = {
@@ -31,6 +31,7 @@ export type GraphEditorProps = {
 	locked: boolean;
 	onInit: (instance: ReactFlowInstance) => void;
 	onFitView: () => void;
+	onAutoLayout: () => void;
 	onToggleLocked: () => void;
 	onZoomIn: () => void;
 	onZoomOut: () => void;
@@ -58,6 +59,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 	nodes,
 	onInit,
 	onFitView,
+	onAutoLayout,
 	locked,
 	onToggleLocked,
 	zoom,
@@ -157,6 +159,11 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 					<Tooltip label={ locked ? "Unlock graph" : "Lock graph" } position="right" >
 						<ActionIcon variant="default" onClick={ onToggleLocked } >
 							<IconElement path={ locked ? mdiLock : mdiLockOpen } />
+						</ActionIcon>
+					</Tooltip>
+					<Tooltip label="Auto Layout" position="right" >
+						<ActionIcon variant="default" onClick={ onAutoLayout } >
+							<IconElement path={ mdiSitemap } rotate={ -90 } />
 						</ActionIcon>
 					</Tooltip>
 				</ActionIcon.Group>

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, memo } from "react";
-import { EditorNodeProps, calcPortOffset, defaultNodeWidth } from "./util";
+import { EditorNodeProps, calcPortOffset } from "./util";
 import { GraphPatcherNodeRecord, GraphPortRecord, PortDirection } from "../../models/graph";
 import EditorPort from "./port";
 import classes from "./editor.module.css";
@@ -21,7 +21,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 		return result;
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
-	const portSizeLimit = sinks.length && sources.length ? Math.round(defaultNodeWidth / 2) : defaultNodeWidth;
+	const portSizeLimit = sinks.length && sources.length ? Math.round(node.width / 2) : node.width;
 
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
@@ -42,7 +42,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 					</Tooltip>
 				</div>
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: defaultNodeWidth }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px` }} >
 				{
 					sinks.map((port, i) => (
 						<EditorPort

--- a/src/components/editor/systemNode.tsx
+++ b/src/components/editor/systemNode.tsx
@@ -21,19 +21,14 @@ const EditorSystemNode: FunctionComponent<EditorNodeProps> = memo(function Wrapp
 	}, { sinks: [], sources: [] } as { sinks: GraphPortRecord[]; sources: GraphPortRecord[]; });
 
 	const aliases = useAppSelector((state: RootStateType) => getPortAliasesForNode(state, node));
-	const longestAliasCharCount = aliases.valueSeq().reduce((result, alias) => {
-		return alias.length > result ? alias.length : result;
-	}, 0);
-
-	const width = 300 + Math.max(0, (longestAliasCharCount - 10) * 5);
-	const portSizeLimit = sinks.length && sources.length ? Math.round(width / 2) : width;
+	const portSizeLimit = sinks.length && sources.length ? Math.round(node.width / 2) : node.width;
 
 	return (
 		<Paper className={ classes.node }  shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
 				{ node.jackName }
 			</div>
-			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px`, minWidth: `${width}px` }} >
+			<div className={ classes.nodeContent } style={{ height: `${node.contentHeight}px` }} >
 				{
 					sinks.map((port, i) => (
 						<EditorPort

--- a/src/components/editor/util.ts
+++ b/src/components/editor/util.ts
@@ -12,9 +12,6 @@ export type EdgeDataProps = {
 export type EditorNodeProps = NodeProps<NodeDataProps>;
 export type EditorEdgeProps = EdgeProps<EdgeDataProps>;
 
-
 export const calcPortOffset = (total: number, index: number): number => {
 	return (index + 1) * (1 / (total + 1)) * 100;
 };
-
-export const defaultNodeWidth = 300;

--- a/src/components/elements/icon.tsx
+++ b/src/components/elements/icon.tsx
@@ -4,7 +4,7 @@ import { parseThemeColor, useMantineTheme } from "@mantine/core";
 import { forwardRef, RefObject } from "react";
 import { IconProps } from "@mdi/react/dist/IconProps";
 
-export const IconElement = forwardRef<SVGSVGElement, IconProps>(({ color, ...props }, ref) => {
+export const IconElement = forwardRef<SVGSVGElement, IconProps>(function WrappedIconElement({ color, ...props }, ref) {
 	const theme = useMantineTheme();
 
 	let iconColor: string | undefined = undefined;

--- a/src/components/elements/icon.tsx
+++ b/src/components/elements/icon.tsx
@@ -1,8 +1,10 @@
 import Icon  from "@mdi/react";
 import classes from "./elements.module.css";
 import { parseThemeColor, useMantineTheme } from "@mantine/core";
+import { forwardRef, RefObject } from "react";
+import { IconProps } from "@mdi/react/dist/IconProps";
 
-export const IconElement: typeof Icon = ({ color, ...props }) => {
+export const IconElement = forwardRef<SVGSVGElement, IconProps>(({ color, ...props }, ref) => {
 	const theme = useMantineTheme();
 
 	let iconColor: string | undefined = undefined;
@@ -12,6 +14,6 @@ export const IconElement: typeof Icon = ({ color, ...props }) => {
 	}
 
 	return (
-		<Icon { ...props } className={ classes.icon } color={ iconColor } />
+		<Icon { ...props } className={ classes.icon } color={ iconColor } ref={ ref as RefObject<SVGSVGElement> } />
 	);
-};
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,6 +24,11 @@ export enum InstanceTab {
 
 export const bodyFontSize = 16;
 
+export const nodeDefaultWidth = 435;
+export const nodeHeaderHeight = 50;
+export const nodePortSpacing = 30;
+export const nodePortHeight = 20;
+
 export enum Breakpoints {
 	xs = 36 * 16,
 	sm = 48 * 16,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,6 +29,9 @@ export const nodeHeaderHeight = 50;
 export const nodePortSpacing = 30;
 export const nodePortHeight = 20;
 
+export const maxEditorZoom = 5;
+export const minEditorZoom = 0.25;
+
 export enum Breakpoints {
 	xs = 36 * 16,
 	sm = 48 * 16,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,7 @@ export const nodeDefaultWidth = 435;
 export const nodeHeaderHeight = 50;
 export const nodePortSpacing = 30;
 export const nodePortHeight = 20;
+export const defaultNodeGap = 150;
 
 export const maxEditorZoom = 5;
 export const minEditorZoom = 0.25;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
 	applyEditorEdgeChanges, applyEditorNodeChanges, createEditorConnection,
 	editorZoomIn,
 	editorZoomOut,
+	generateEditorLayout,
 	removeEditorConnectionsById, removeEditorNodesById,
 	toggleEditorLockedState,
 	triggerEditorFitView
@@ -74,6 +75,20 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 	const onEditorToggleLocked = useCallback(() => {
 		dispatch(toggleEditorLockedState());
 	}, [dispatch]);
+
+	const onEditorAutoLayout = useCallback(() => {
+		modals.openConfirmModal({
+			title: "Rerrange Graph",
+			centered: true,
+			children: (
+				<Text size="sm">
+					Are you sure you want to automatically layout the current graph? This action cannot be undone.
+				</Text>
+			),
+			labels: { confirm: "Confirm", cancel: "Cancel" },
+			onConfirm: () => dispatch(generateEditorLayout())
+		});
+	}, []);
 
 	const onEditorZoomIn = useCallback(() => {
 		dispatch(editorZoomIn());
@@ -213,6 +228,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 					onEdgesDelete={ onEdgesDelete }
 
 					onInit={ onEditorInit }
+					onAutoLayout={ onEditorAutoLayout }
 					onFitView={ onEditorFitView }
 					onToggleLocked={ onEditorToggleLocked }
 					locked={ editorLocked }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -88,7 +88,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 			labels: { confirm: "Confirm", cancel: "Cancel" },
 			onConfirm: () => dispatch(generateEditorLayout())
 		});
-	}, []);
+	}, [dispatch]);
 
 	const onEditorZoomIn = useCallback(() => {
 		dispatch(editorZoomIn());

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,7 +82,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 			centered: true,
 			children: (
 				<Text size="sm">
-					Are you sure you want to automatically layout the current graph? This action cannot be undone.
+					Are you sure you want to rearrange and auto-layout the current graph? This action cannot be undone.
 				</Text>
 			),
 			labels: { confirm: "Confirm", cancel: "Cancel" },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,12 @@
 import { Button, Group, Stack, Text, Tooltip } from "@mantine/core";
-import { FunctionComponent, useCallback } from "react";
+import { FunctionComponent, useCallback, useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "../hooks/useAppDispatch";
 import { RootStateType } from "../lib/store";
 import { getPatchersSortedByName } from "../selectors/patchers";
 import { getConnections, getNodes } from "../selectors/graph";
 import GraphEditor from "../components/editor";
 import PresetDrawer from "../components/presets";
-import { Connection, Edge, EdgeChange, Node, NodeChange } from "reactflow";
+import { Connection, Edge, EdgeChange, Node, NodeChange, ReactFlowInstance } from "reactflow";
 import {
 	applyEditorEdgeChanges, applyEditorNodeChanges, createEditorConnection,
 	removeEditorConnectionsById, removeEditorNodesById,
@@ -26,6 +26,7 @@ import { modals } from "@mantine/modals";
 import { IconElement } from "../components/elements/icon";
 import { mdiCamera, mdiFileExport, mdiGroup } from "@mdi/js";
 import { ResponsiveButton } from "../components/elements/responsiveButton";
+import { initEditor, unmountEditor } from "../actions/editor";
 
 const Index: FunctionComponent<Record<string, never>> = () => {
 
@@ -53,6 +54,11 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		dispatch(loadPatcherNodeOnRemote(patcher));
 		closePatcherDrawer();
 	}, [dispatch, closePatcherDrawer]);
+
+	// Editor
+	const onEditorInit = useCallback((instance: ReactFlowInstance) => {
+		dispatch(initEditor(instance));
+	}, [dispatch]);
 
 	// Nodes
 	const onConnectNodes = useCallback((connection: Connection) => {
@@ -145,6 +151,10 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		dispatch(renamePatcherOnRemote(p, name));
 	}, [dispatch]);
 
+	useEffect(() => {
+		return () => dispatch(unmountEditor());
+	}, [dispatch]);
+
 	return (
 		<>
 			<Stack style={{ height: "100%" }} >
@@ -177,6 +187,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 					onNodesDelete={ onNodesDelete }
 					onEdgesChange={ onEdgesChange }
 					onEdgesDelete={ onEdgesDelete }
+					onInit={ onEditorInit }
 				/>
 			</Stack>
 			<PatcherDrawer

--- a/src/reducers/editor.ts
+++ b/src/reducers/editor.ts
@@ -1,0 +1,28 @@
+import { EditorAction, EditorActionType } from "../actions/editor";
+import { ReactFlowInstance } from "reactflow";
+
+export type EditorState = {
+	instance?: ReactFlowInstance;
+};
+
+export const editor = (state: EditorState = {}, action: EditorAction): EditorState => {
+	switch (action.type) {
+
+		case EditorActionType.INIT: {
+			return {
+				...state,
+				instance: action.payload.instance
+			};
+		}
+
+		case EditorActionType.UNMOUNT: {
+			return {
+				...state,
+				instance: undefined
+			};
+		}
+
+		default:
+			return state;
+	}
+};

--- a/src/reducers/editor.ts
+++ b/src/reducers/editor.ts
@@ -3,9 +3,12 @@ import { ReactFlowInstance } from "reactflow";
 
 export type EditorState = {
 	instance?: ReactFlowInstance;
+	isLocked: boolean;
 };
 
-export const editor = (state: EditorState = {}, action: EditorAction): EditorState => {
+export const editor = (state: EditorState = {
+	isLocked: false
+}, action: EditorAction): EditorState => {
 	switch (action.type) {
 
 		case EditorActionType.INIT: {
@@ -19,6 +22,13 @@ export const editor = (state: EditorState = {}, action: EditorAction): EditorSta
 			return {
 				...state,
 				instance: undefined
+			};
+		}
+
+		case EditorActionType.SET_LOCKED: {
+			return {
+				...state,
+				isLocked: action.payload.locked
 			};
 		}
 

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 
 import { appStatus } from "./appStatus";
 import { datafiles } from "./datafiles";
+import { editor } from "./editor";
 import { instances } from "./instances";
 import { graph } from "./graph";
 import { nofitications } from "./notifications";
@@ -13,6 +14,7 @@ import { transport } from "./transport";
 export const rootReducer = combineReducers({
 	appStatus,
 	datafiles,
+	editor,
 	instances,
 	graph,
 	nofitications,

--- a/src/selectors/editor.ts
+++ b/src/selectors/editor.ts
@@ -1,0 +1,5 @@
+import { ReactFlowInstance } from "reactflow";
+import { RootStateType } from "../lib/store";
+
+export const getGraphEditorInstance = (state: RootStateType): ReactFlowInstance | undefined => state.editor.instance;
+export const getGraphEditorLockedState = (state: RootStateType): boolean => state.editor.isLocked;


### PR DESCRIPTION
This moves some of the viewport / editor pane interactions into actions & the state. The version of Reactflow we use doesn't fully support a controlled viewport but this gets us there.

Note that with this PR:

* the built-in controls menu is replaced with a custom one to also feature the layouting button
* we introduce an auto-layout functionality
* width & height of all nodes are controlled in the graph (but not resizable just yet)
* new patcher nodes should be placed in 0,0 of the current viewport

The migration of existing sets might be a bit clumsy due to the state controlled width & height but hopefully the auto-layout makes this smoother and easier to deal with?!

see #168

Also created #187 for node resizing

