### PR TITLE
Add Global MIDI Mapping View

### DIFF
--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -576,27 +576,27 @@ export const clearParameterMIDIMappingOnRemote = (id: PatcherInstanceRecord["id"
 	};
 
 export const setParameterMIDIChannelOnRemote = (id: PatcherInstanceRecord["id"], paramId: ParameterRecord["id"], channel: number): AppThunk =>
-		(_dispatch, getState) => {
-			const state = getState();
-			const instance = getPatcherInstance(state, id);
-			if (!instance) return;
+	(_dispatch, getState) => {
+		const state = getState();
+		const instance = getPatcherInstance(state, id);
+		if (!instance) return;
 
-			const param = getPatcherInstanceParameter(state, paramId);
-			if (!param) return;
+		const param = getPatcherInstanceParameter(state, paramId);
+		if (!param) return;
 
-			const meta: ParameterMetaJsonMap = cloneJSON(param.meta);
-			meta.midi = (meta.midi || {});
-			meta.midi.chan = channel;
+		const meta: ParameterMetaJsonMap = cloneJSON(param.meta);
+		meta.midi = (meta.midi || {});
+		meta.midi.chan = channel;
 
-			const message = {
-				address: `${param.path}/meta`,
-				args: [
-					{ type: "s", value: JSON.stringify(meta) }
-				]
-			};
-
-			oscQueryBridge.sendPacket(writePacket(message));
+		const message = {
+			address: `${param.path}/meta`,
+			args: [
+				{ type: "s", value: JSON.stringify(meta) }
+			]
 		};
+
+		oscQueryBridge.sendPacket(writePacket(message));
+	};
 
 export const setParameterMIDIControlOnRemote = (id: PatcherInstanceRecord["id"], paramId: ParameterRecord["id"], control: number): AppThunk =>
 	(_dispatch, getState) => {

--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -16,6 +16,7 @@ import { AppSetting } from "../models/settings";
 import { DataRefRecord } from "../models/dataref";
 import { DataFileRecord } from "../models/datafile";
 import { PatcherExportRecord } from "../models/patcher";
+import { cloneJSON } from "../lib/util";
 
 export enum PatcherActionType {
 	INIT_PATCHERS = "INIT_PATCHERS",
@@ -561,7 +562,7 @@ export const clearParameterMidiMappingOnRemote = (id: PatcherInstanceRecord["id"
 		const param = getPatcherInstanceParameter(state, paramId);
 		if (!param) return;
 
-		const meta = { ...param.meta };
+		const meta = cloneJSON(param.meta);
 		delete meta.midi;
 		const message = {
 			address: `${param.path}/meta`,
@@ -848,7 +849,7 @@ export const updateInstanceMIDILastValue = (index: number, value: string): AppTh
 			const parameters: ParameterRecord[] = [];
 			getPatcherInstanceParametersByInstanceIndex(state, instance.index).forEach(param => {
 				if (param.waitingForMidiMapping) {
-					const meta = { ...param.meta };
+					const meta = cloneJSON(param.meta);
 					meta.midi = midiMeta;
 
 					const message = {

--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -561,7 +561,7 @@ export const clearParameterMidiMappingOnRemote = (id: PatcherInstanceRecord["id"
 		const param = getPatcherInstanceParameter(state, paramId);
 		if (!param) return;
 
-		const meta = param.getParsedMetaObject();
+		const meta = { ...param.meta };
 		delete meta.midi;
 		const message = {
 			address: `${param.path}/meta`,
@@ -848,7 +848,7 @@ export const updateInstanceMIDILastValue = (index: number, value: string): AppTh
 			const parameters: ParameterRecord[] = [];
 			getPatcherInstanceParametersByInstanceIndex(state, instance.index).forEach(param => {
 				if (param.waitingForMidiMapping) {
-					const meta = param.getParsedMetaObject();
+					const meta = { ...param.meta };
 					meta.midi = midiMeta;
 
 					const message = {

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -26,9 +26,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 	return (
 		<Paper className={ classes.node } shadow="md" withBorder data-selected={ selected } >
 			<div className={ classes.nodeHeader } >
-				<div>
-					{ (node as GraphPatcherNodeRecord).index }: { (node as GraphPatcherNodeRecord).patcher }
-				</div>
+				<div>{ (node as GraphPatcherNodeRecord).displayName }</div>
 				<div>
 					<Tooltip label="Open Patcher Instance Control">
 						<ActionIcon

--- a/src/components/elements/editableTableCell.tsx
+++ b/src/components/elements/editableTableCell.tsx
@@ -1,5 +1,6 @@
-import { NumberInput, Table } from "@mantine/core";
-import { FC, memo, useCallback, useEffect, useState } from "react";
+import { NumberInput, Table, TextInput } from "@mantine/core";
+import { ChangeEvent, FC, KeyboardEvent, memo, useCallback, useEffect, useState } from "react";
+import classes from "./elements.module.css";
 
 export type EditableTableNumberCellProps = {
 	className?: string;
@@ -7,15 +8,17 @@ export type EditableTableNumberCellProps = {
 	max: number;
 	name: string;
 	onUpdate: (val: number) => void;
+	prefix?: string;
 	value: number;
 };
 
-export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(function WrappedEditableMIDIField({
+export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(function WrappedEditableNumberField({
 	className = "",
 	min,
 	max,
 	name,
 	onUpdate,
+	prefix,
 	value
 }) {
 	const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -37,6 +40,19 @@ export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(fu
 		onUpdate(currentValue);
 	}, [setIsEditing, value, currentValue, onUpdate]);
 
+	const onKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>): void => {
+		if (e.key === "Escape") {
+			setIsEditing(false);
+			setCurrentValue(value);
+			return void e.preventDefault();
+		} else if (e.key === "Enter") {
+			setIsEditing(false);
+			if (currentValue === value) return;
+			onUpdate(currentValue);
+			return void e.preventDefault();
+		}
+	}, [setIsEditing, setCurrentValue, value, currentValue, onUpdate]);
+
 	useEffect(() => {
 		setCurrentValue(value);
 	}, [value, setCurrentValue]);
@@ -47,16 +63,90 @@ export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(fu
 				isEditing ? (
 					<NumberInput
 						autoFocus
+						className={ classes.editableTableCellInput }
 						variant="unstyled"
 						onBlur={ onBlur }
 						onChange={ onChange }
+						onKeyDown={ onKeyDown }
 						name={ name }
 						min={ min }
 						max={ max }
+						prefix={ prefix }
 						size="xs"
 						value={ currentValue }
 					/>
-				) :  value
+				) : `${prefix || ""}${value}`
+			}
+
+		</Table.Td>
+	);
+});
+
+export type EditableTableTextCellProps = {
+	className?: string;
+	name: string;
+	onUpdate: (val: string) => void;
+	value: string;
+};
+
+export const EditableTableTextCell: FC<EditableTableTextCellProps> = memo(function WrappedEditableTextField({
+	className = "",
+	name,
+	onUpdate,
+	value
+}) {
+	const [isEditing, setIsEditing] = useState<boolean>(false);
+	const [currentValue, setCurrentValue] = useState<string>(value);
+
+	const onTriggerEdit = useCallback(() => {
+		if (isEditing) return;
+		setIsEditing(true);
+		setCurrentValue(value);
+	}, [isEditing, setIsEditing, setCurrentValue, value]);
+
+	const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+		setCurrentValue(e.target.value);
+	}, [setCurrentValue]);
+
+	const onBlur = useCallback(() => {
+		setIsEditing(false);
+		if (currentValue === value) return;
+		onUpdate(currentValue);
+	}, [setIsEditing, value, currentValue, onUpdate]);
+
+	const onKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>): void => {
+		if (e.key === "Escape") {
+			setIsEditing(false);
+			setCurrentValue(value);
+			return void e.preventDefault();
+		} else if (e.key === "Enter") {
+			setIsEditing(false);
+			if (currentValue === value) return;
+			onUpdate(currentValue);
+			return void e.preventDefault();
+		}
+	}, [setIsEditing, setCurrentValue, value, currentValue, onUpdate]);
+
+	useEffect(() => {
+		setCurrentValue(value);
+	}, [value, setCurrentValue]);
+
+	return (
+		<Table.Td className={ className } onClick={ onTriggerEdit } py={ 0 } >
+			{
+				isEditing ? (
+					<TextInput
+						autoFocus
+						className={ classes.editableTableCellInput }
+						variant="unstyled"
+						onBlur={ onBlur }
+						onChange={ onChange }
+						onKeyDown={ onKeyDown }
+						name={ name }
+						size="xs"
+						value={ currentValue }
+					/>
+				) : value
 			}
 
 		</Table.Td>

--- a/src/components/elements/editableTableCell.tsx
+++ b/src/components/elements/editableTableCell.tsx
@@ -1,5 +1,5 @@
-import { Group, NumberInput, Table } from "@mantine/core";
-import { FC, memo, useCallback, useEffect, useState } from "react"
+import { NumberInput, Table } from "@mantine/core";
+import { FC, memo, useCallback, useEffect, useState } from "react";
 
 export type EditableTableNumberCellProps = {
 	className?: string;
@@ -8,7 +8,7 @@ export type EditableTableNumberCellProps = {
 	name: string;
 	onUpdate: (val: number) => void;
 	value: number;
-}
+};
 
 export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(function WrappedEditableMIDIField({
 	className = "",
@@ -60,5 +60,5 @@ export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(fu
 			}
 
 		</Table.Td>
-	)
-})
+	);
+});

--- a/src/components/elements/editableTableCell.tsx
+++ b/src/components/elements/editableTableCell.tsx
@@ -1,0 +1,64 @@
+import { Group, NumberInput, Table } from "@mantine/core";
+import { FC, memo, useCallback, useEffect, useState } from "react"
+
+export type EditableTableNumberCellProps = {
+	className?: string;
+	min: number;
+	max: number;
+	name: string;
+	onUpdate: (val: number) => void;
+	value: number;
+}
+
+export const EditableTableNumberCell: FC<EditableTableNumberCellProps> = memo(function WrappedEditableMIDIField({
+	className = "",
+	min,
+	max,
+	name,
+	onUpdate,
+	value
+}) {
+	const [isEditing, setIsEditing] = useState<boolean>(false);
+	const [currentValue, setCurrentValue] = useState<number>(value);
+
+	const onTriggerEdit = useCallback(() => {
+		if (isEditing) return;
+		setIsEditing(true);
+		setCurrentValue(value);
+	}, [isEditing, setIsEditing, setCurrentValue, value]);
+
+	const onChange = useCallback((val: number) => {
+		setCurrentValue(val);
+	}, [setCurrentValue]);
+
+	const onBlur = useCallback(() => {
+		setIsEditing(false);
+		if (currentValue === value) return;
+		onUpdate(currentValue);
+	}, [setIsEditing, value, currentValue, onUpdate]);
+
+	useEffect(() => {
+		setCurrentValue(value);
+	}, [value, setCurrentValue]);
+
+	return (
+		<Table.Td className={ className } onClick={ onTriggerEdit } py={ 0 } >
+			{
+				isEditing ? (
+					<NumberInput
+						autoFocus
+						variant="unstyled"
+						onBlur={ onBlur }
+						onChange={ onChange }
+						name={ name }
+						min={ min }
+						max={ max }
+						size="xs"
+						value={ currentValue }
+					/>
+				) :  value
+			}
+
+		</Table.Td>
+	)
+})

--- a/src/components/elements/elements.module.css
+++ b/src/components/elements/elements.module.css
@@ -1,3 +1,7 @@
 .icon {
 	width: 1.3em;
 }
+
+.editableTableCellInput {
+	border-bottom: 1px solid var(--mantine-primary-color-filled);
+}

--- a/src/components/elements/elements.module.css
+++ b/src/components/elements/elements.module.css
@@ -1,7 +1,3 @@
 .icon {
 	width: 1.3em;
 }
-
-.tableHeaderButton {
-	width: 100%;
-}

--- a/src/components/elements/elements.module.css
+++ b/src/components/elements/elements.module.css
@@ -1,3 +1,7 @@
 .icon {
 	width: 1.3em;
 }
+
+.tableHeaderButton {
+	width: 100%;
+}

--- a/src/components/elements/tableHeaderCell.tsx
+++ b/src/components/elements/tableHeaderCell.tsx
@@ -3,7 +3,6 @@ import { FC, PropsWithChildren, useCallback } from "react";
 import { SortOrder } from "../../lib/constants";
 import { IconElement } from "./icon";
 import { mdiChevronDown, mdiChevronUp, mdiUnfoldMoreHorizontal } from "@mdi/js";
-import classes from "./elements.module.css";
 
 export type TableHeaderCellProps = PropsWithChildren<{
 	className?: string;
@@ -35,7 +34,7 @@ export const TableHeaderCell: FC<TableHeaderCellProps> = ({
 		<Table.Th className={ className } >
 			{
 				onSort ? (
-					<UnstyledButton onClick={ onTriggerSort } className={ classes.tableHeaderButton } >
+					<UnstyledButton onClick={ onTriggerSort } >
 						<Group justify="space-between">
 							<Text fw="bold" fz={ fz } >
 								{ children }

--- a/src/components/elements/tableHeaderCell.tsx
+++ b/src/components/elements/tableHeaderCell.tsx
@@ -1,0 +1,58 @@
+import { Group, MantineFontSize, Table, Text, UnstyledButton } from "@mantine/core";
+import { FC, PropsWithChildren, useCallback } from "react";
+import { SortOrder } from "../../lib/constants";
+import { IconElement } from "./icon";
+import { mdiChevronDown, mdiChevronUp, mdiUnfoldMoreHorizontal } from "@mdi/js";
+import classes from "./elements.module.css";
+
+export type TableHeaderCellProps = PropsWithChildren<{
+	className?: string;
+	fz?: MantineFontSize;
+
+	onSort?: (sortKey: string) => void;
+	sorted?: boolean;
+	sortKey?: string;
+	sortOrder?: SortOrder;
+}>;
+
+export const TableHeaderCell: FC<TableHeaderCellProps> = ({
+	children,
+	className,
+	fz = "sm",
+
+	onSort,
+	sorted = false,
+	sortKey,
+	sortOrder = SortOrder.Asc
+
+}) => {
+
+	const onTriggerSort = useCallback(() => {
+		onSort?.(sortKey);
+	}, [onSort, sortKey]);
+
+	return (
+		<Table.Th className={ className } >
+			{
+				onSort ? (
+					<UnstyledButton onClick={ onTriggerSort } className={ classes.tableHeaderButton } >
+						<Group justify="space-between">
+							<Text fw="bold" fz={ fz } >
+								{ children }
+							</Text>
+							{
+								sorted
+									? <IconElement size={ 0.7 } path={ sortOrder === SortOrder.Asc ? mdiChevronDown : mdiChevronUp } />
+									: <IconElement size={ 0.5 } path={ mdiUnfoldMoreHorizontal } color={ "gray.6" } />
+							}
+						</Group>
+					</UnstyledButton>
+				) : (
+					<Text fw="bold" fz={ fz } >
+						{ children }
+					</Text>
+				)
+			}
+		</Table.Th>
+	);
+};

--- a/src/components/instance/paramTab.tsx
+++ b/src/components/instance/paramTab.tsx
@@ -9,7 +9,7 @@ import { PatcherInstanceRecord } from "../../models/instance";
 import {
 	restoreDefaultParameterMetaOnRemote, setInstanceParameterMetaOnRemote,
 	setInstanceParameterValueNormalizedOnRemote,
-	setInstanceWaitingForMidiMappingOnRemote, clearParameterMidiMappingOnRemote,
+	setInstanceWaitingForMidiMappingOnRemote, clearParameterMIDIMappingOnRemote,
 	activateParameterMIDIMappingFocus
 } from "../../actions/patchers";
 import { OrderedSet as ImmuOrderedSet, Map as ImmuMap } from "immutable";
@@ -159,7 +159,7 @@ const InstanceParameterTab: FunctionComponent<InstanceParameterTabProps> = memo(
 	}, [dispatch, instance]);
 
 	const onClearParameterMidiMapping = useCallback((param: ParameterRecord) => {
-		dispatch(clearParameterMidiMappingOnRemote(instance.id, param.id));
+		dispatch(clearParameterMIDIMappingOnRemote(instance.id, param.id));
 	}, [dispatch, instance]);
 
 	const onSearch = useDebouncedCallback((query: string) => {

--- a/src/components/messages/inport.tsx
+++ b/src/components/messages/inport.tsx
@@ -49,7 +49,7 @@ const MessageInportEntry: FunctionComponent<MessageInportEntryProps> = memo(func
 						onClose={ closeMetaEditor }
 						onRestore={ onRestoreMeta }
 						onSaveMeta={ onSaveMeta }
-						meta={ port.meta }
+						meta={ port.metaString }
 						name={ port.name }
 						scope={ MetadataScope.Inport }
 					/>

--- a/src/components/messages/outport.tsx
+++ b/src/components/messages/outport.tsx
@@ -42,7 +42,7 @@ const MessageOutportEntry: FunctionComponent<MessageOutportEntryProps> = memo(fu
 						onClose={ closeMetaEditor }
 						onRestore={ onRestoreMeta }
 						onSaveMeta={ onSaveMeta }
-						meta={ port.meta }
+						meta={ port.metaString }
 						name={ port.name }
 						scope={ MetadataScope.Outport }
 					/>

--- a/src/components/meta/metaEditorModal.tsx
+++ b/src/components/meta/metaEditorModal.tsx
@@ -4,7 +4,7 @@ import { useIsMobileDevice } from "../../hooks/useIsMobileDevice";
 import { modals } from "@mantine/modals";
 import { JsonMap } from "../../lib/types";
 import { MetadataScope } from "../../lib/constants";
-import { parseParamMetaJSONString } from "../../lib/util";
+import { parseMetaJSONString } from "../../lib/util";
 import classes from "./metaEditorModal.module.css";
 import { IconElement } from "../elements/icon";
 import { mdiClose, mdiCodeBraces } from "@mdi/js";
@@ -129,7 +129,7 @@ export const MetaEditorModal: FC<MetaEditorModalProps> = memo(function WrappedPa
 					setHasChanges(false);
 
 					try {
-						if (meta) parseParamMetaJSONString(meta); // ensure valid
+						if (meta) parseMetaJSONString(meta); // ensure valid
 						setError(undefined);
 					} catch (err: unknown) {
 						setError(err instanceof Error ? err : new Error("Invalid JSON format."));
@@ -140,7 +140,7 @@ export const MetaEditorModal: FC<MetaEditorModalProps> = memo(function WrappedPa
 			setValue(meta);
 			setHasChanges(false);
 			try {
-				parseParamMetaJSONString(meta); // ensure valid
+				parseMetaJSONString(meta); // ensure valid
 				setError(undefined);
 			} catch (err: unknown) {
 				setError(err instanceof Error ? err : new Error("Invalid JSON format."));
@@ -152,7 +152,7 @@ export const MetaEditorModal: FC<MetaEditorModalProps> = memo(function WrappedPa
 		if (error) {
 			try {
 				const v = e.currentTarget.value;
-				if (v) parseParamMetaJSONString(v); // ensure valid
+				if (v) parseMetaJSONString(v); // ensure valid
 				setError(undefined);
 			} catch (err: unknown) {
 				setError(err instanceof Error ? err : new Error("Invalid JSON format."));
@@ -165,7 +165,7 @@ export const MetaEditorModal: FC<MetaEditorModalProps> = memo(function WrappedPa
 	const onInputBlur = useCallback(() => {
 		try {
 			if (value) {
-				const j: JsonMap = parseParamMetaJSONString(value); // ensure valid
+				const j: JsonMap = parseMetaJSONString(value); // ensure valid
 				setValue(JSON.stringify(j, null, 2));
 			}
 			setError(undefined);
@@ -177,7 +177,7 @@ export const MetaEditorModal: FC<MetaEditorModalProps> = memo(function WrappedPa
 	const onSaveValue = useCallback((e: FormEvent) => {
 		e.preventDefault();
 		try {
-			if (value) parseParamMetaJSONString(value); // ensure valid
+			if (value) parseMetaJSONString(value); // ensure valid
 			setHasChanges(false);
 			onSaveMeta(value);
 		} catch (err: unknown) {

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -1,0 +1,82 @@
+import { FC, memo, useCallback } from "react";
+import { PatcherInstanceRecord } from "../../models/instance";
+import { ParameterRecord } from "../../models/parameter";
+import { ActionIcon, Group, Menu, Table, Text, Tooltip } from "@mantine/core";
+import { mdiDotsVertical, mdiEraser, mdiVectorSquare } from "@mdi/js";
+import { IconElement } from "../elements/icon";
+import { modals } from "@mantine/modals";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import classes from "./midi.module.css";
+import { formatParamValueForDisplay } from "../../lib/util";
+
+export type MIDIMappedParamProps = {
+	instance: PatcherInstanceRecord;
+	param: ParameterRecord;
+	onClearMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
+};
+
+const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIMappedParam({
+	instance,
+	param,
+	onClearMIDIMapping
+}) {
+
+	const { query: restQuery } = useRouter();
+
+	const onClearMapping = useCallback(() => {
+		modals.openConfirmModal({
+			title: "Clear Parameter MIDI Mapping",
+			centered: true,
+			children: (
+				<Text size="sm" id="red">
+					Are you sure you want to remove the active MIDI mapping for { `"${param.name}"` } on patcher instance { `"${instance.displayName}"` }?
+				</Text>
+			),
+			labels: { confirm: "Remove", cancel: "Cancel" },
+			confirmProps: { color: "red" },
+			onConfirm: () => onClearMIDIMapping(instance, param)
+		});
+	}, [param, instance]);
+
+	return (
+		<Table.Tr>
+			<Table.Td className={ classes.midiChannelColumn } >{ param.meta.midi?.chan || ""}</Table.Td>
+			<Table.Td className={ classes.midiControlColumn } >{ param.meta.midi?.ctrl || ""}</Table.Td>
+			<Table.Td className={ classes.parameterNameColumn } >{ param.name }</Table.Td>
+			<Table.Td className={ classes.patcherInstanceColumn } >
+				<span className={ classes.patcherInstanceIndex } >{ instance.index }</span>
+				<span className={ classes.patcherInstanceName } >: {instance.name}</span>
+			</Table.Td>
+			<Table.Td className={ classes.parameterValueColumn } >{ formatParamValueForDisplay(param.value) }</Table.Td>
+			<Table.Td className={ classes.actionColumn } >
+				<Group justify="flex-end">
+					<Menu position="bottom-end">
+						<Menu.Target>
+							<Tooltip label="Open Action Menu">
+								<ActionIcon variant="subtle" color="gray" >
+									<IconElement path={ mdiDotsVertical } />
+								</ActionIcon>
+							</Tooltip>
+						</Menu.Target>
+						<Menu.Dropdown>
+							<Menu.Label>MIDI Mapping Actions</Menu.Label>
+							<Menu.Item
+								leftSection={ <IconElement path={ mdiVectorSquare } /> }
+								component={ Link }
+								href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instance.index } }}
+							>
+								Show Instance
+							</Menu.Item>
+							<Menu.Item color="red" leftSection={ <IconElement path={ mdiEraser } /> } onClick={ onClearMapping } >
+								Remove MIDI Mapping
+							</Menu.Item>
+						</Menu.Dropdown>
+					</Menu>
+				</Group>
+			</Table.Td>
+		</Table.Tr>
+	);
+});
+
+export default MIDIMappedParameter;

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -37,7 +37,7 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 			confirmProps: { color: "red" },
 			onConfirm: () => onClearMIDIMapping(instance, param)
 		});
-	}, [param, instance]);
+	}, [param, instance, onClearMIDIMapping]);
 
 	return (
 		<Table.Tr>

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -8,23 +8,47 @@ import { modals } from "@mantine/modals";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import classes from "./midi.module.css";
-import { formatParamValueForDisplay } from "../../lib/util";
-import { EditableTableNumberCell } from "../elements/editableTableCell";
+import { formatMIDIMappingToDisplay, formatParamValueForDisplay } from "../../lib/util";
+import { EditableTableTextCell } from "../elements/editableTableCell";
+import { MIDIMetaMappingType } from "../../lib/constants";
+import { MIDIMetaMapping } from "../../lib/types";
+
+export type MIDISourceProps = {
+	mappingType: MIDIMetaMappingType;
+	midiMapping: MIDIMetaMapping;
+	onUpdateMapping: (value: string) => void;
+};
+
+
+const MIDISource: FC<MIDISourceProps> = memo(function WrappedMIDISource({
+	mappingType,
+	midiMapping,
+	onUpdateMapping
+}) {
+
+	return (
+		<EditableTableTextCell
+			className={ classes.midiSourceColumn }
+			name="midi_source"
+			onUpdate={ onUpdateMapping }
+			value={ formatMIDIMappingToDisplay(mappingType, midiMapping) }
+		/>
+	);
+});
 
 export type MIDIMappedParamProps = {
 	instance: PatcherInstanceRecord;
 	param: ParameterRecord;
 	onClearMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
-	onUpdateMIDIChannel: (instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => void;
-	onUpdateMIDIControl: (instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => void;
+	onUpdateMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord, value: string) => void;
 };
+
 
 const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIMappedParam({
 	instance,
 	param,
 	onClearMIDIMapping,
-	onUpdateMIDIChannel,
-	onUpdateMIDIControl
+	onUpdateMIDIMapping
 }) {
 
 	const { query: restQuery } = useRouter();
@@ -44,26 +68,17 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 		});
 	}, [param, instance, onClearMIDIMapping]);
 
-	const onUpdateChannel = useCallback((channel: number) => {
-		onUpdateMIDIChannel(instance, param, channel);
-	}, [onUpdateMIDIChannel, instance, param]);
-
-	const onUpdateControl = useCallback((control: number) => {
-		onUpdateMIDIControl(instance, param, control);
-	}, [onUpdateMIDIControl, instance, param]);
+	const onUpdateMapping = useCallback((value: string) => {
+		onUpdateMIDIMapping(instance, param, value);
+	}, [instance, param, onUpdateMIDIMapping]);
 
 	return (
 		<Table.Tr>
-			{
-				param.meta.midi?.chan === undefined
-					? <Table.Td className={ classes.midiChannelColumn } />
-					: <EditableTableNumberCell min={ 1 } max={ 16 } value={ param.meta.midi.chan } name="midi_channel" className={ classes.midiChannelColumn } onUpdate={ onUpdateChannel } />
-			}
-			{
-				param.meta.midi?.ctrl === undefined
-					? <Table.Td className={ classes.midiControlColumn } />
-					: <EditableTableNumberCell min={ 0 } max={ 127 } value={ param.meta.midi.ctrl } name="midi_control" className={ classes.midiControlColumn } onUpdate={ onUpdateControl } />
-			}
+			<MIDISource
+				mappingType={ param.midiMappingType as MIDIMetaMappingType }
+				midiMapping={ param.meta.midi as MIDIMetaMapping }
+				onUpdateMapping={ onUpdateMapping }
+			/>
 			<Table.Td className={ classes.parameterNameColumn } >{ param.name }</Table.Td>
 			<Table.Td className={ classes.patcherInstanceColumn } >
 				<span className={ classes.patcherInstanceIndex } >{ instance.index }</span>

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -9,17 +9,22 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import classes from "./midi.module.css";
 import { formatParamValueForDisplay } from "../../lib/util";
+import { EditableTableNumberCell } from "../elements/editableTableCell";
 
 export type MIDIMappedParamProps = {
 	instance: PatcherInstanceRecord;
 	param: ParameterRecord;
 	onClearMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
+	onUpdateMIDIChannel: (instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => void;
+	onUpdateMIDIControl: (instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => void;
 };
 
 const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIMappedParam({
 	instance,
 	param,
-	onClearMIDIMapping
+	onClearMIDIMapping,
+	onUpdateMIDIChannel,
+	onUpdateMIDIControl
 }) {
 
 	const { query: restQuery } = useRouter();
@@ -39,10 +44,26 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 		});
 	}, [param, instance, onClearMIDIMapping]);
 
+	const onUpdateChannel = useCallback((channel: number) => {
+		onUpdateMIDIChannel(instance, param, channel);
+	}, [onUpdateMIDIChannel, instance, param]);
+
+	const onUpdateControl = useCallback((control: number) => {
+		onUpdateMIDIControl(instance, param, control);
+	}, [onUpdateMIDIControl, instance, param]);
+
 	return (
 		<Table.Tr>
-			<Table.Td className={ classes.midiChannelColumn } >{ param.meta.midi?.chan || ""}</Table.Td>
-			<Table.Td className={ classes.midiControlColumn } >{ param.meta.midi?.ctrl || ""}</Table.Td>
+			{
+				param.meta.midi?.chan === undefined
+					? <Table.Td className={ classes.midiChannelColumn } />
+					: <EditableTableNumberCell min={ 1 } max={ 16 } value={ param.meta.midi.chan } name="midi_channel" className={ classes.midiChannelColumn } onUpdate={ onUpdateChannel } />
+			}
+			{
+				param.meta.midi?.ctrl === undefined
+					? <Table.Td className={ classes.midiControlColumn } />
+					: <EditableTableNumberCell min={ 0 } max={ 127 } value={ param.meta.midi.ctrl } name="midi_control" className={ classes.midiControlColumn } onUpdate={ onUpdateControl } />
+			}
 			<Table.Td className={ classes.parameterNameColumn } >{ param.name }</Table.Td>
 			<Table.Td className={ classes.patcherInstanceColumn } >
 				<span className={ classes.patcherInstanceIndex } >{ instance.index }</span>

--- a/src/components/midi/mappedParameterList.tsx
+++ b/src/components/midi/mappedParameterList.tsx
@@ -80,19 +80,20 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 				{
 					parameters.map(p => {
 						const pInstance = patcherInstances.get(p.instanceIndex);
-						return pInstance
-							?	<MIDIMappedParameter
-									key={ p.id }
-									instance={ pInstance }
-									param={ p }
-									onClearMIDIMapping={ onClearParameterMidiMapping }
-								/>
-							: null;
+						if (!pInstance) return null;
+						return (
+							<MIDIMappedParameter
+								key={ p.id }
+								instance={ pInstance }
+								param={ p }
+								onClearMIDIMapping={ onClearParameterMidiMapping }
+							/>
+						);
 					})
 				}
 			</Table.Tbody>
 		</Table>
 	);
-})
+});
 
 export default MIDIMappedParameterList;

--- a/src/components/midi/mappedParameterList.tsx
+++ b/src/components/midi/mappedParameterList.tsx
@@ -11,7 +11,9 @@ import { MIDIMappedParameterSortAttr, SortOrder } from "../../lib/constants";
 export type MIDIMappedParameterListProps = {
 	parameters: ImmuOrderedSet<ParameterRecord>;
 	patcherInstances: ImmuMap<PatcherInstanceRecord["index"], PatcherInstanceRecord>;
-	onClearParameterMidiMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
+	onClearParameterMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
+	onUpdateParameterMIDIChannel: (instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => void;
+	onUpdateParameterMIDIControl: (instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => void;
 	onSort: (sortAttr: MIDIMappedParameterSortAttr) => void;
 	sortAttr: MIDIMappedParameterSortAttr;
 	sortOrder: SortOrder;
@@ -20,7 +22,9 @@ export type MIDIMappedParameterListProps = {
 const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function WrappedMIDIMappedParameterList({
 	patcherInstances,
 	parameters,
-	onClearParameterMidiMapping,
+	onClearParameterMIDIMapping,
+	onUpdateParameterMIDIChannel,
+	onUpdateParameterMIDIControl,
 	onSort,
 	sortAttr,
 	sortOrder
@@ -86,7 +90,9 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 								key={ p.id }
 								instance={ pInstance }
 								param={ p }
-								onClearMIDIMapping={ onClearParameterMidiMapping }
+								onClearMIDIMapping={ onClearParameterMIDIMapping }
+								onUpdateMIDIChannel={ onUpdateParameterMIDIChannel }
+								onUpdateMIDIControl={ onUpdateParameterMIDIControl }
 							/>
 						);
 					})

--- a/src/components/midi/mappedParameterList.tsx
+++ b/src/components/midi/mappedParameterList.tsx
@@ -1,0 +1,98 @@
+import { Map as ImmuMap, Set as ImmuOrderedSet } from "immutable";
+import { Table } from "@mantine/core";
+import { FC, memo } from "react";
+import classes from "./midi.module.css";
+import { PatcherInstanceRecord } from "../../models/instance";
+import { ParameterRecord } from "../../models/parameter";
+import MIDIMappedParameter from "./mappedParameterItem";
+import { TableHeaderCell } from "../elements/tableHeaderCell";
+import { MIDIMappedParameterSortAttr, SortOrder } from "../../lib/constants";
+
+export type MIDIMappedParameterListProps = {
+	parameters: ImmuOrderedSet<ParameterRecord>;
+	patcherInstances: ImmuMap<PatcherInstanceRecord["index"], PatcherInstanceRecord>;
+	onClearParameterMidiMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
+	onSort: (sortAttr: MIDIMappedParameterSortAttr) => void;
+	sortAttr: MIDIMappedParameterSortAttr;
+	sortOrder: SortOrder;
+};
+
+const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function WrappedMIDIMappedParameterList({
+	patcherInstances,
+	parameters,
+	onClearParameterMidiMapping,
+	onSort,
+	sortAttr,
+	sortOrder
+}) {
+
+	return (
+		<Table verticalSpacing="sm" maw="100%" layout="fixed" highlightOnHover>
+			<Table.Thead>
+				<Table.Tr>
+					<TableHeaderCell
+						className={ classes.midiChannelColumnHeader }
+						fz="xs"
+						onSort={ onSort }
+						sortKey={ MIDIMappedParameterSortAttr.MIDIChannel }
+						sortOrder={ sortOrder }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.MIDIChannel }
+					>
+						Channel
+					</TableHeaderCell>
+					<TableHeaderCell
+						className={ classes.midiControlColumnHeader }
+						fz="xs"
+						onSort={ onSort }
+						sortKey={ MIDIMappedParameterSortAttr.MIDIControl }
+						sortOrder={ sortOrder }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.MIDIControl }
+					>
+						Control
+					</TableHeaderCell>
+					<TableHeaderCell
+						className={ classes.parameterNameColumnHeader }
+						fz="xs"
+						onSort={ onSort }
+						sortKey={ MIDIMappedParameterSortAttr.ParameterName }
+						sortOrder={ sortOrder }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.ParameterName }
+					>
+						Parameter
+					</TableHeaderCell>
+					<TableHeaderCell
+						className={ classes.patcherInstanceColumnHeader }
+						fz="xs"
+						onSort={ onSort }
+						sortKey={ MIDIMappedParameterSortAttr.InstanceIndex }
+						sortOrder={ sortOrder }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.InstanceIndex }
+					>
+						Instance
+					</TableHeaderCell>
+					<TableHeaderCell className={ classes.parameterValueColumnHeader } fz="xs" >
+						Current Value
+					</TableHeaderCell>
+					<TableHeaderCell className={ classes.actionColumnHeader } />
+				</Table.Tr>
+			</Table.Thead>
+			<Table.Tbody>
+				{
+					parameters.map(p => {
+						const pInstance = patcherInstances.get(p.instanceIndex);
+						return pInstance
+							?	<MIDIMappedParameter
+									key={ p.id }
+									instance={ pInstance }
+									param={ p }
+									onClearMIDIMapping={ onClearParameterMidiMapping }
+								/>
+							: null;
+					})
+				}
+			</Table.Tbody>
+		</Table>
+	);
+})
+
+export default MIDIMappedParameterList;

--- a/src/components/midi/mappedParameterList.tsx
+++ b/src/components/midi/mappedParameterList.tsx
@@ -12,8 +12,7 @@ export type MIDIMappedParameterListProps = {
 	parameters: ImmuOrderedSet<ParameterRecord>;
 	patcherInstances: ImmuMap<PatcherInstanceRecord["index"], PatcherInstanceRecord>;
 	onClearParameterMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord) => void;
-	onUpdateParameterMIDIChannel: (instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => void;
-	onUpdateParameterMIDIControl: (instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => void;
+	onUpdateParameterMIDIMapping: (instance: PatcherInstanceRecord, param: ParameterRecord, value: string) => void;
 	onSort: (sortAttr: MIDIMappedParameterSortAttr) => void;
 	sortAttr: MIDIMappedParameterSortAttr;
 	sortOrder: SortOrder;
@@ -23,8 +22,7 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 	patcherInstances,
 	parameters,
 	onClearParameterMIDIMapping,
-	onUpdateParameterMIDIChannel,
-	onUpdateParameterMIDIControl,
+	onUpdateParameterMIDIMapping,
 	onSort,
 	sortAttr,
 	sortOrder
@@ -35,24 +33,14 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 			<Table.Thead>
 				<Table.Tr>
 					<TableHeaderCell
-						className={ classes.midiChannelColumnHeader }
+						className={ classes.midiSourceColumnHeader }
 						fz="xs"
 						onSort={ onSort }
-						sortKey={ MIDIMappedParameterSortAttr.MIDIChannel }
+						sortKey={ MIDIMappedParameterSortAttr.MIDISource }
 						sortOrder={ sortOrder }
-						sorted={ sortAttr === MIDIMappedParameterSortAttr.MIDIChannel }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.MIDISource }
 					>
-						Channel
-					</TableHeaderCell>
-					<TableHeaderCell
-						className={ classes.midiControlColumnHeader }
-						fz="xs"
-						onSort={ onSort }
-						sortKey={ MIDIMappedParameterSortAttr.MIDIControl }
-						sortOrder={ sortOrder }
-						sorted={ sortAttr === MIDIMappedParameterSortAttr.MIDIControl }
-					>
-						Control
+						Source
 					</TableHeaderCell>
 					<TableHeaderCell
 						className={ classes.parameterNameColumnHeader }
@@ -91,8 +79,7 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 								instance={ pInstance }
 								param={ p }
 								onClearMIDIMapping={ onClearParameterMIDIMapping }
-								onUpdateMIDIChannel={ onUpdateParameterMIDIChannel }
-								onUpdateMIDIControl={ onUpdateParameterMIDIControl }
+								onUpdateMIDIMapping={ onUpdateParameterMIDIMapping }
 							/>
 						);
 					})

--- a/src/components/midi/midi.module.css
+++ b/src/components/midi/midi.module.css
@@ -1,10 +1,9 @@
-.midiChannelColumnHeader,
-.midiControlColumnHeader {
+.midiSourceColumnHeader {
 	width: 100px;
 }
 
-.midiChannelColumn,
-.midiControlColumn {
+.midiSourceColumn {
+	cursor: text;
 	font-size: var(--mantine-font-size-xs);
 }
 
@@ -13,6 +12,7 @@
 	cursor: default;
 	display: none;
 	font-size: var(--mantine-font-size-xs);
+	user-select: none;
 
 	@media (min-width: $mantine-breakpoint-md) {
 		display: table-cell;
@@ -21,7 +21,7 @@
 }
 
 .patcherInstanceColumnHeader {
-	width: 80px;
+	width: 100px;
 
 	@media (min-width: $mantine-breakpoint-md) {
 		width: initial;
@@ -33,6 +33,7 @@
 	font-size: var(--mantine-font-size-xs);
 	overflow: hidden;
 	text-overflow: ellipsis;
+	user-select: none;
 	white-space: nowrap;
 
 	.patcherInstanceName {
@@ -44,12 +45,16 @@
 	}
 }
 
-.parameterNameColumnHeader {}
+.parameterNameColumnHeader {
+	width: 150px;
+}
+
 .parameterNameColumn {
 	cursor: default;
 	font-size: var(--mantine-font-size-xs);
 	overflow: hidden;
 	text-overflow: ellipsis;
+	user-select: none;
 	white-space: nowrap;
 }
 

--- a/src/components/midi/midi.module.css
+++ b/src/components/midi/midi.module.css
@@ -10,6 +10,7 @@
 
 .parameterValueColumnHeader,
 .parameterValueColumn {
+	cursor: default;
 	display: none;
 	font-size: var(--mantine-font-size-xs);
 
@@ -28,6 +29,7 @@
 }
 
 .patcherInstanceColumn {
+	cursor: default;
 	font-size: var(--mantine-font-size-xs);
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -44,6 +46,7 @@
 
 .parameterNameColumnHeader {}
 .parameterNameColumn {
+	cursor: default;
 	font-size: var(--mantine-font-size-xs);
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/components/midi/midi.module.css
+++ b/src/components/midi/midi.module.css
@@ -1,0 +1,56 @@
+.midiChannelColumnHeader,
+.midiControlColumnHeader {
+	width: 100px;
+}
+
+.midiChannelColumn,
+.midiControlColumn {
+	font-size: var(--mantine-font-size-xs);
+}
+
+.parameterValueColumnHeader,
+.parameterValueColumn {
+	display: none;
+	font-size: var(--mantine-font-size-xs);
+
+	@media (min-width: $mantine-breakpoint-md) {
+		display: table-cell;
+		width: 200px;
+  }
+}
+
+.patcherInstanceColumnHeader {
+	width: 80px;
+
+	@media (min-width: $mantine-breakpoint-md) {
+		width: initial;
+	}
+}
+
+.patcherInstanceColumn {
+	font-size: var(--mantine-font-size-xs);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	.patcherInstanceName {
+		display: none;
+
+		@media (min-width: $mantine-breakpoint-md) {
+			display: inline-block;
+		}
+	}
+}
+
+.parameterNameColumnHeader {}
+.parameterNameColumn {
+	font-size: var(--mantine-font-size-xs);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.actionColumnHeader {
+	width: 10px;
+}
+.actionColumn {}

--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -9,7 +9,7 @@ import { getShowSettingsModal } from "../../selectors/settings";
 import { ExternalNavLink, NavLink } from "./link";
 import { useRouter } from "next/router";
 import { getFirstPatcherNodeIndex } from "../../selectors/graph";
-import { mdiChartSankeyVariant, mdiCog, mdiFileMusic, mdiHelpCircle, mdiVectorSquare } from "@mdi/js";
+import { mdiChartSankeyVariant, mdiCog, mdiFileMusic, mdiHelpCircle, mdiMidiPort, mdiVectorSquare } from "@mdi/js";
 
 const AppNav: FunctionComponent = memo(function WrappedNav() {
 
@@ -50,6 +50,12 @@ const AppNav: FunctionComponent = memo(function WrappedNav() {
 						label="Audio Files"
 						href={{ pathname: "/files", query: restQuery }}
 						isActive={ pathname === "/files" }
+					/>
+					<NavLink
+						icon={ mdiMidiPort }
+						label="MIDI Mappings"
+						href={{ pathname: "/midimappings", query: restQuery }}
+						isActive={ pathname === "/midimappings" }
 					/>
 				</Stack>
 				<Stack className={ classes.navMenu } >

--- a/src/components/nav/nav.module.css
+++ b/src/components/nav/nav.module.css
@@ -16,13 +16,14 @@
 	color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
 	display: flex;
 	height: rem(50px);
-	padding: 0 var(--mantine-spacing-sm);
-  justify-content: center;
+	padding: 0 var(--mantine-spacing-md);
+  justify-content: flex-start;
 	width: 100%;
 
 	@media (min-width: $mantine-breakpoint-md) {
 		border-radius: var(--mantine-radius-md);
 		padding: 0;
+		justify-content: center;
 		width: rem(50px);
   }
 

--- a/src/components/parameter/item.tsx
+++ b/src/components/parameter/item.tsx
@@ -145,7 +145,7 @@ const Parameter = memo(function WrappedParameter({
 						<Menu.Item leftSection={ <IconElement path={ mdiCodeBraces } /> } onClick={ toggleMetaEditor }>
 							Edit Metadata
 						</Menu.Item>
-						<Menu.Item leftSection={ <IconElement path={ mdiEraser } /> } onClick={ onClearMidiMap } disabled={ !param.isMidiMapped } >
+						<Menu.Item color="red" leftSection={ <IconElement path={ mdiEraser } /> } onClick={ onClearMidiMap } disabled={ !param.isMidiMapped } >
 							Clear MIDI Mapping
 						</Menu.Item>
 					</Menu.Dropdown>

--- a/src/components/parameter/item.tsx
+++ b/src/components/parameter/item.tsx
@@ -8,12 +8,9 @@ import { MetadataScope } from "../../lib/constants";
 import { IconElement } from "../elements/icon";
 import { mdiCodeBraces, mdiDotsVertical, mdiEraser } from "@mdi/js";
 import { modals } from "@mantine/modals";
+import { formatParamValueForDisplay } from "../../lib/util";
 
 export const parameterBoxHeight = 87 + 6; // 87px + 6px margin
-const formatParamValueForDisplay = (value: number | string) => {
-	if (typeof value === "number") return Number.isInteger(value) ? value : value.toFixed(2);
-	return value;
-};
 
 interface ParameterProps {
 	instanceIsMIDIMapping: boolean;

--- a/src/components/parameter/item.tsx
+++ b/src/components/parameter/item.tsx
@@ -92,7 +92,7 @@ const Parameter = memo(function WrappedParameter({
 						onClose={ closeMetaEditor }
 						onRestore={ onRestoreMeta }
 						onSaveMeta={ onSaveMeta }
-						meta={ param.meta }
+						meta={ param.metaString }
 						name={ param.name }
 						scope={ MetadataScope.Parameter }
 					/>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -72,10 +72,18 @@ export enum SortOrder {
 }
 
 export enum MIDIMappedParameterSortAttr {
-	MIDIChannel = "midi_channel",
-	MIDIControl = "midi_control",
+	MIDISource = "midi_source",
 	InstanceIndex = "instance_index",
 	ParameterName = "param_name"
+}
+
+export enum MIDIMetaMappingType {
+	ChannelPressure = "channel_pressure",
+	ControlChange = "control_change",
+	KeyPressure = "key_pressure",
+	Note = "note",
+	PitchBend = "pitch_bend",
+	ProgramChange = "progam_change"
 }
 
 export enum ParameterSortAttr {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -71,6 +71,13 @@ export enum SortOrder {
 	Desc = "desc"
 }
 
+export enum MIDIMappedParameterSortAttr {
+	MIDIChannel = "midi_channel",
+	MIDIControl = "midi_control",
+	InstanceIndex = "instance_index",
+	ParameterName = "param_name"
+}
+
 export enum ParameterSortAttr {
 	Index = "displayorder",
 	Name = "name"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,11 +9,40 @@ export type AnyJson =
 
 export interface JsonMap {  [key: string]: AnyJson }
 
+export type MIDIControlChangeMetaMapping = {
+	chan: number;
+	ctrl: number;
+};
+
+export type MIDINoteMetaMapping = {
+	chan: number;
+	note: number;
+};
+
+export type MIDIKeypressMetaMapping = {
+	chan: number;
+	keypress: number;
+};
+
+export type MIDIPitchBendMetaMapping = {
+	bend: number;
+};
+
+export type MIDIProgramChangeMetaMapping = {
+	prgchg: number;
+};
+
+export type MIDIChannelPressureMetaMapping = {
+	chanpress: number;
+};
+
+export type MIDIIndividualScopedMetaMapping = MIDIControlChangeMetaMapping | MIDINoteMetaMapping | MIDIKeypressMetaMapping;
+export type MIDIChannelScopedMetaMapping = MIDIPitchBendMetaMapping | MIDIProgramChangeMetaMapping | MIDIChannelPressureMetaMapping;
+
+export type MIDIMetaMapping = MIDIIndividualScopedMetaMapping | MIDIChannelScopedMetaMapping;
+
 export type ParameterMetaJsonMap = JsonMap & {
-	midi?: {
-		chan?: number;
-		ctrl?: number;
-	}
+	midi?: MIDIMetaMapping;
 };
 
 export type OSCValue = string | number | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,13 @@ export type AnyJson =
 
 export interface JsonMap {  [key: string]: AnyJson }
 
+export type ParameterMetaJsonMap = JsonMap & {
+	midi?: {
+		chan?: number;
+		ctrl?: number;
+	}
+};
+
 export type OSCValue = string | number | null;
 
 export enum OSCAccess {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -59,3 +59,8 @@ export const validateMetaJSONString = (v: string): boolean => {
 		return false;
 	}
 };
+
+export const formatParamValueForDisplay = (value: number | string) => {
+	if (typeof value === "number") return Number.isInteger(value) ? value : value.toFixed(2);
+	return value;
+};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,5 +1,6 @@
 import { KeyboardEvent } from "react";
-import { AnyJson, JsonMap, OSCQueryStringValueRange, OSCQueryValueRange } from "./types";
+import { AnyJson, JsonMap, MIDIChannelPressureMetaMapping, MIDIControlChangeMetaMapping, MIDIKeypressMetaMapping, MIDIMetaMapping, MIDINoteMetaMapping, MIDIPitchBendMetaMapping, MIDIProgramChangeMetaMapping, OSCQueryStringValueRange, OSCQueryValueRange } from "./types";
+import { MIDIMetaMappingType } from "./constants";
 
 export const sleep = (t: number): Promise<void> => new Promise(resolve => setTimeout(resolve, t));
 
@@ -66,3 +67,121 @@ export const formatParamValueForDisplay = (value: number | string) => {
 };
 
 export const cloneJSON = (value: JsonMap): JsonMap => JSON.parse(JSON.stringify(value));
+
+export const formatMIDIMappingToDisplay = (type: MIDIMetaMappingType, mapping: MIDIMetaMapping): string => {
+	switch (type) {
+		case MIDIMetaMappingType.ChannelPressure: {
+			return `CPRESS/${(mapping as MIDIChannelPressureMetaMapping).chanpress}`;
+		}
+		case MIDIMetaMappingType.ControlChange: {
+			return `CC#${(mapping as MIDIControlChangeMetaMapping).ctrl}/${(mapping as MIDIControlChangeMetaMapping).chan}`;
+		}
+		case MIDIMetaMappingType.KeyPressure: {
+			return `KPRESS#${(mapping as MIDIKeypressMetaMapping).keypress}/${(mapping as MIDIKeypressMetaMapping).chan}`;
+		}
+		case MIDIMetaMappingType.Note: {
+			return `NOTE#${(mapping as MIDINoteMetaMapping).note}/${(mapping as MIDINoteMetaMapping).chan}`;
+		}
+		case MIDIMetaMappingType.PitchBend: {
+			return `BEND/${(mapping as MIDIPitchBendMetaMapping).bend}`;
+		}
+		case MIDIMetaMappingType.ProgramChange: {
+			return `PRGCHG/${(mapping as MIDIProgramChangeMetaMapping).prgchg}`;
+		}
+		default: {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const _exhaustive: never = type;
+			throw new Error(`Unknown MIDIMappingType "${type}"`);
+		}
+	}
+};
+
+const midiMetaRegexp: Record<MIDIMetaMappingType, RegExp> = {
+	[MIDIMetaMappingType.ChannelPressure]: /^CPRESS\/(?<chanpress>[0-9]{1,2})$/,
+	[MIDIMetaMappingType.ControlChange]: /^CC#(?<ctrl>[0-9]{1,3})\/(?<chan>[0-9]{1,2})$/,
+	[MIDIMetaMappingType.KeyPressure]: /^KPRESS#(?<keypress>[0-9]{1,3})\/(?<chan>[0-9]{1,2})$/,
+	[MIDIMetaMappingType.Note]: /^NOTE#(?<note>[0-9]{1,3})\/(?<chan>[0-9]{1,2})$/,
+	[MIDIMetaMappingType.PitchBend]: /^BEND\/(?<bend>[0-9]{1,2})$/,
+	[MIDIMetaMappingType.ProgramChange]: /^PRGCHG\/(?<prgchg>[0-9]{1,2})$/
+};
+
+export const parseMIDIMappingDisplayValue = (value: string): false | { type: MIDIMetaMappingType, mapping: MIDIMetaMapping } => {
+	for (const [mappingType, reg] of Object.entries(midiMetaRegexp) as Array<[MIDIMetaMappingType, RegExp]>) {
+		const match = value.match(reg);
+		if (!match) continue;
+
+		switch (mappingType) {
+			case MIDIMetaMappingType.ChannelPressure: {
+				const chanpress = parseInt(match.groups.chanpress, 10);
+				if (isNaN(chanpress) || chanpress < 1 || chanpress > 16) return false;
+				return {
+					type: MIDIMetaMappingType.ChannelPressure,
+					mapping: { chanpress } as MIDIChannelPressureMetaMapping
+				};
+			}
+			case MIDIMetaMappingType.ControlChange: {
+				const chan = parseInt(match.groups.chan, 10);
+				if (isNaN(chan) || chan < 1 || chan > 16) return false;
+
+				const ctrl = parseInt(match.groups.ctrl, 10);
+				if (isNaN(ctrl) || ctrl < 0 || ctrl > 127) return false;
+
+				return {
+					type: MIDIMetaMappingType.ControlChange,
+					mapping: { chan, ctrl } as MIDIControlChangeMetaMapping
+				};
+			}
+			case MIDIMetaMappingType.KeyPressure: {
+				const chan = parseInt(match.groups.chan, 10);
+				if (isNaN(chan) || chan < 1 || chan > 16) return false;
+
+				const keypress = parseInt(match.groups.keypress, 10);
+				if (isNaN(keypress) || keypress < 0 || keypress > 127) return false;
+
+				return {
+					type: MIDIMetaMappingType.KeyPressure,
+					mapping: { chan, keypress } as MIDIKeypressMetaMapping
+				};
+
+			}
+			case MIDIMetaMappingType.Note: {
+				const chan = parseInt(match.groups.chan, 10);
+				if (isNaN(chan) || chan < 1 || chan > 16) return false;
+
+				const note = parseInt(match.groups.note, 10);
+				if (isNaN(note) || note < 0 || note > 127) return false;
+
+				return {
+					type: MIDIMetaMappingType.Note,
+					mapping: { chan, note } as MIDINoteMetaMapping
+				};
+
+			}
+			case MIDIMetaMappingType.PitchBend: {
+				const bend = parseInt(match.groups.bend, 10);
+				if (isNaN(bend) || bend < 1 || bend > 16) return false;
+				return {
+					type: MIDIMetaMappingType.PitchBend,
+					mapping: { bend } as MIDIPitchBendMetaMapping
+				};
+
+			}
+			case MIDIMetaMappingType.ProgramChange: {
+				const prgchg = parseInt(match.groups.prgchg, 10);
+				if (isNaN(prgchg) || prgchg < 1 || prgchg > 16) return false;
+				return {
+					type: MIDIMetaMappingType.ProgramChange,
+					mapping: { prgchg } as MIDIProgramChangeMetaMapping
+				};
+			}
+
+			default: {
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const _exhaustive: never = mappingType;
+				throw new Error(`Unknown MIDIMappingType "${mappingType}"`);
+			}
+		}
+	}
+
+	return false;
+};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -37,7 +37,7 @@ export const formatFileSize = (size: number): string => {
 	return (size / Math.pow(1000, exp)).toFixed(exp >= 2 ? 2 : 0) + " " + fileSizeUnits[exp];
 };
 
-export const parseParamMetaJSONString = (v: string): JsonMap => {
+export const parseMetaJSONString = (v: string): JsonMap => {
 	if (!v?.length) return {};
 
 	let parsed: AnyJson;
@@ -51,9 +51,9 @@ export const parseParamMetaJSONString = (v: string): JsonMap => {
 	return parsed;
 };
 
-export const validateParamMetaJSONString = (v: string): boolean => {
+export const validateMetaJSONString = (v: string): boolean => {
 	try {
-		parseParamMetaJSONString(v);
+		parseMetaJSONString(v);
 		return true;
 	} catch (err) {
 		return false;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -91,7 +91,7 @@ export const formatMIDIMappingToDisplay = (type: MIDIMetaMappingType, mapping: M
 		default: {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const _exhaustive: never = type;
-			throw new Error(`Unknown MIDIMappingType "${type}"`);
+			return "Unknown";
 		}
 	}
 };
@@ -105,26 +105,43 @@ const midiMetaRegexp: Record<MIDIMetaMappingType, RegExp> = {
 	[MIDIMetaMappingType.ProgramChange]: /^PRGCHG\/(?<prgchg>[0-9]{1,2})$/
 };
 
-export const parseMIDIMappingDisplayValue = (value: string): false | { type: MIDIMetaMappingType, mapping: MIDIMetaMapping } => {
+const parseMIDIByte = (val: string, min: number, max: number): number | null => {
+	if (val === undefined) return null;
+  const n = parseInt(val, 10);
+  if (isNaN(n) || n < min || n > max) return null;
+  return n;
+};
+
+export class InvalidMIDIFormatError extends Error {
+	constructor() {
+		super("Invalid MIDI mapping");
+	}
+}
+
+export class UnknownMIDIFormatError extends Error {
+	constructor() {
+		super("Unknown MIDI mapping format");
+	}
+}
+
+export const parseMIDIMappingDisplayValue = (value: string): { type: MIDIMetaMappingType, mapping: MIDIMetaMapping } => {
 	for (const [mappingType, reg] of Object.entries(midiMetaRegexp) as Array<[MIDIMetaMappingType, RegExp]>) {
 		const match = value.match(reg);
 		if (!match) continue;
 
 		switch (mappingType) {
 			case MIDIMetaMappingType.ChannelPressure: {
-				const chanpress = parseInt(match.groups.chanpress, 10);
-				if (isNaN(chanpress) || chanpress < 1 || chanpress > 16) return false;
+				const chanpress = parseMIDIByte(match.groups?.chanpress, 1, 16);
+				if (chanpress === null) throw new Error(`"${value}" is not a valid MIDI mapping format`);
 				return {
 					type: MIDIMetaMappingType.ChannelPressure,
 					mapping: { chanpress } as MIDIChannelPressureMetaMapping
 				};
 			}
 			case MIDIMetaMappingType.ControlChange: {
-				const chan = parseInt(match.groups.chan, 10);
-				if (isNaN(chan) || chan < 1 || chan > 16) return false;
-
-				const ctrl = parseInt(match.groups.ctrl, 10);
-				if (isNaN(ctrl) || ctrl < 0 || ctrl > 127) return false;
+				const chan = parseMIDIByte(match.groups?.chan, 1, 16);
+				const ctrl = parseMIDIByte(match.groups?.ctrl, 0, 127);
+				if (chan === null || ctrl === null) throw new InvalidMIDIFormatError();
 
 				return {
 					type: MIDIMetaMappingType.ControlChange,
@@ -132,11 +149,9 @@ export const parseMIDIMappingDisplayValue = (value: string): false | { type: MID
 				};
 			}
 			case MIDIMetaMappingType.KeyPressure: {
-				const chan = parseInt(match.groups.chan, 10);
-				if (isNaN(chan) || chan < 1 || chan > 16) return false;
-
-				const keypress = parseInt(match.groups.keypress, 10);
-				if (isNaN(keypress) || keypress < 0 || keypress > 127) return false;
+				const chan = parseMIDIByte(match.groups?.chan, 1, 16);
+				const keypress = parseMIDIByte(match.groups?.keypress, 0, 127);
+				if (chan === null || keypress === null) throw new InvalidMIDIFormatError();
 
 				return {
 					type: MIDIMetaMappingType.KeyPressure,
@@ -145,11 +160,9 @@ export const parseMIDIMappingDisplayValue = (value: string): false | { type: MID
 
 			}
 			case MIDIMetaMappingType.Note: {
-				const chan = parseInt(match.groups.chan, 10);
-				if (isNaN(chan) || chan < 1 || chan > 16) return false;
-
-				const note = parseInt(match.groups.note, 10);
-				if (isNaN(note) || note < 0 || note > 127) return false;
+				const chan = parseMIDIByte(match.groups?.chan, 1, 16);
+				const note = parseMIDIByte(match.groups?.note, 0, 127);
+				if (chan === null || note === null) throw new InvalidMIDIFormatError();
 
 				return {
 					type: MIDIMetaMappingType.Note,
@@ -158,8 +171,9 @@ export const parseMIDIMappingDisplayValue = (value: string): false | { type: MID
 
 			}
 			case MIDIMetaMappingType.PitchBend: {
-				const bend = parseInt(match.groups.bend, 10);
-				if (isNaN(bend) || bend < 1 || bend > 16) return false;
+				const bend = parseMIDIByte(match.groups?.bend, 1, 16);
+				if (bend === null) throw new InvalidMIDIFormatError();
+
 				return {
 					type: MIDIMetaMappingType.PitchBend,
 					mapping: { bend } as MIDIPitchBendMetaMapping
@@ -167,8 +181,9 @@ export const parseMIDIMappingDisplayValue = (value: string): false | { type: MID
 
 			}
 			case MIDIMetaMappingType.ProgramChange: {
-				const prgchg = parseInt(match.groups.prgchg, 10);
-				if (isNaN(prgchg) || prgchg < 1 || prgchg > 16) return false;
+				const prgchg = parseMIDIByte(match.groups?.prgchg, 1, 16);
+				if (prgchg === null) throw new InvalidMIDIFormatError();
+
 				return {
 					type: MIDIMetaMappingType.ProgramChange,
 					mapping: { prgchg } as MIDIProgramChangeMetaMapping
@@ -178,10 +193,9 @@ export const parseMIDIMappingDisplayValue = (value: string): false | { type: MID
 			default: {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				const _exhaustive: never = mappingType;
-				throw new Error(`Unknown MIDIMappingType "${mappingType}"`);
 			}
 		}
 	}
 
-	return false;
+	throw new UnknownMIDIFormatError();
 };

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -107,9 +107,9 @@ const midiMetaRegexp: Record<MIDIMetaMappingType, RegExp> = {
 
 const parseMIDIByte = (val: string, min: number, max: number): number | null => {
 	if (val === undefined) return null;
-  const n = parseInt(val, 10);
-  if (isNaN(n) || n < min || n > max) return null;
-  return n;
+	const n = parseInt(val, 10);
+	if (isNaN(n) || n < min || n > max) return null;
+	return n;
 };
 
 export class InvalidMIDIFormatError extends Error {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -64,3 +64,5 @@ export const formatParamValueForDisplay = (value: number | string) => {
 	if (typeof value === "number") return Number.isInteger(value) ? value : value.toFixed(2);
 	return value;
 };
+
+export const cloneJSON = (value: JsonMap): JsonMap => JSON.parse(JSON.stringify(value));

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -112,6 +112,10 @@ export class GraphPatcherNodeRecord extends ImmuRecord<GraphPatcherNodeProps>({
 		return this.ports.get(id);
 	}
 
+	public get displayName(): string {
+		return `${this.index}: ${this.patcher}`;
+	}
+
 	public get id(): string {
 		return this.jackName;
 	}

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -45,6 +45,10 @@ export class PatcherInstanceRecord extends ImmuRecord<PatcherInstanceProps>({
 
 }) {
 
+	public get displayName(): string {
+		return `${this.index}: ${this.name}`;
+	}
+
 	public get id(): string {
 		return this.name;
 	}

--- a/src/models/parameter.ts
+++ b/src/models/parameter.ts
@@ -132,6 +132,8 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 			midiMappingType = MIDIMetaMappingType.Note;
 		} else if (Object.hasOwn(parsed.midi, "prgchg")) {
 			midiMappingType = MIDIMetaMappingType.ProgramChange;
+		} else {
+			midiMappingType = false;
 		}
 
 		return this.withMutations(p => {

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Stack, Table, Text, UnstyledButton } from "@mantine/core";
+import { Button, Group, Stack, Table, Text } from "@mantine/core";
 import { DataFileListItem } from "../components/datafile/item";
 import { useAppDispatch, useAppSelector } from "../hooks/useAppDispatch";
 import { RootStateType } from "../lib/store";
@@ -14,7 +14,8 @@ import { modals } from "@mantine/modals";
 import { NotificationLevel } from "../models/notification";
 import { showNotification } from "../actions/notifications";
 import { IconElement } from "../components/elements/icon";
-import { mdiSortAlphabeticalAscending, mdiSortAlphabeticalDescending, mdiUpload } from "@mdi/js";
+import { mdiUpload } from "@mdi/js";
+import { TableHeaderCell } from "../components/elements/tableHeaderCell";
 
 const SampleDependencies = () => {
 
@@ -61,14 +62,9 @@ const SampleDependencies = () => {
 			<Table verticalSpacing="sm" maw="100%" layout="fixed" highlightOnHover>
 				<Table.Thead>
 					<Table.Tr>
-						<Table.Th>
-							<UnstyledButton onClick={ onToggleSort } className={ classes.control } >
-								<Group justify="space-between" align="center">
-									<Text fw="bold" fz="sm">Filename</Text>
-									<IconElement path={ sortOrder === SortOrder.Asc ? mdiSortAlphabeticalAscending : mdiSortAlphabeticalDescending } />
-								</Group>
-							</UnstyledButton>
-						</Table.Th>
+						<TableHeaderCell onSort={ onToggleSort } sortKey={ "filename" } sortOrder={ sortOrder } sorted >
+							Filename
+						</TableHeaderCell>
 						<Table.Th w={ 60 }></Table.Th>
 					</Table.Tr>
 				</Table.Thead>

--- a/src/pages/instances/[index].tsx
+++ b/src/pages/instances/[index].tsx
@@ -131,7 +131,7 @@ export default function Instance() {
 			<Group justify="space-between" wrap="nowrap">
 				<div style={{ flex: "1 2 50%" }} >
 					<NativeSelect
-						data={ instances.valueSeq().sortBy(n => n.index).toArray().map(d => ({ value: `${d.index}`, label: `${d.index}: ${d.patcher}` })) }
+						data={ instances.valueSeq().sortBy(n => n.index).toArray().map(d => ({ value: `${d.index}`, label: d.displayName })) }
 						leftSection={ <IconElement path={ mdiVectorSquare } /> }
 						onChange={ onChangeInstance }
 						value={ currentInstance.index }

--- a/src/pages/midimappings.tsx
+++ b/src/pages/midimappings.tsx
@@ -1,0 +1,128 @@
+import { OrderedSet as ImmuOrderedSet, Map as ImmuMap } from "immutable";
+import { Stack } from "@mantine/core";
+import { useAppDispatch, useAppSelector } from "../hooks/useAppDispatch";
+import { RootStateType } from "../lib/store";
+import classes from "../components/midi/midi.module.css";
+import { MIDIMappedParameterSortAttr, SortOrder } from "../lib/constants";
+import { useCallback, useEffect, useState } from "react";
+import { getPatcherInstanceParametersWithMIDIMapping, getPatcherInstancesByIndex } from "../selectors/patchers";
+import MIDIMappedParameterList from "../components/midi/mappedParameterList";
+import { ParameterRecord } from "../models/parameter";
+import { clearParameterMidiMappingOnRemote } from "../actions/patchers";
+import { PatcherInstanceRecord } from "../models/instance";
+
+const collator = new Intl.Collator("en-US");
+const parameterComparators: Record<MIDIMappedParameterSortAttr, Record<SortOrder, (a: ParameterRecord, b: ParameterRecord) => number>> = {
+	[MIDIMappedParameterSortAttr.MIDIChannel]: {
+		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.meta.midi?.chan < b.meta.midi?.chan) return -1;
+			if (a.meta.midi?.chan > b.meta.midi?.chan) return 1;
+			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return -1;
+			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return 1;
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+		},
+		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.meta.midi?.chan > b.meta.midi?.chan) return -1;
+			if (a.meta.midi?.chan < b.meta.midi?.chan) return 1;
+			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return -1;
+			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return 1;
+
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
+		}
+	},
+	[MIDIMappedParameterSortAttr.MIDIControl]: {
+		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return -1;
+			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return 1;
+			if (a.meta.midi?.chan < b.meta.midi?.chan) return -1;
+			if (a.meta.midi?.chan > b.meta.midi?.chan) return 1;
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+		},
+		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return -1;
+			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return 1;
+			if (a.meta.midi?.chan > b.meta.midi?.chan) return -1;
+			if (a.meta.midi?.chan < b.meta.midi?.chan) return 1;
+
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
+		}
+	},
+	[MIDIMappedParameterSortAttr.InstanceIndex]: {
+		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.instanceIndex < b.instanceIndex) return -1;
+			if (a.instanceIndex > b.instanceIndex) return 1;
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+		},
+		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
+			if (a.instanceIndex > b.instanceIndex) return -1;
+			if (a.instanceIndex < b.instanceIndex) return 1;
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
+		}
+	},
+	[MIDIMappedParameterSortAttr.ParameterName]: {
+		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+		},
+		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
+			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
+		}
+	}
+};
+
+const getSortedParameterIds = (params: ImmuMap<ParameterRecord["id"], ParameterRecord>, attr: MIDIMappedParameterSortAttr, order: SortOrder): ImmuOrderedSet<ParameterRecord["id"]> => {
+	return ImmuOrderedSet<ParameterRecord["id"]>(params.valueSeq().sort(parameterComparators[attr][order]).map(p => p.id));
+};
+
+const MIDIMappings = () => {
+
+	const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.Asc);
+	const [sortAttr, setSortAttr] = useState<MIDIMappedParameterSortAttr>(MIDIMappedParameterSortAttr.MIDIChannel);
+	const [sortedParameterIds, setSortedParameterIds] = useState<ImmuOrderedSet<ParameterRecord["id"]>>(ImmuOrderedSet<ParameterRecord["id"]>());
+
+	const dispatch = useAppDispatch();
+	const [
+		patcherInstances,
+		parameters
+	] = useAppSelector((state: RootStateType) => [
+		getPatcherInstancesByIndex(state),
+		getPatcherInstanceParametersWithMIDIMapping(state)
+	]);
+
+	const onClearParameterMidiMapping = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord) => {
+		dispatch(clearParameterMidiMappingOnRemote(instance.id, param.id));
+	}, [dispatch]);
+
+	const onSort = useCallback((attr: MIDIMappedParameterSortAttr) => {
+		if (attr === sortAttr) return setSortOrder(sortOrder === SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc);
+
+		setSortAttr(attr);
+		setSortOrder(SortOrder.Asc);
+
+	}, [sortOrder, sortAttr, setSortOrder, setSortAttr]);
+
+	useEffect(() => {
+		setSortedParameterIds(getSortedParameterIds(parameters, sortAttr, sortOrder));
+	}, [patcherInstances, parameters.size, sortAttr, sortOrder]);
+
+	const displayParameters = ImmuOrderedSet<ParameterRecord>().withMutations(set => {
+		sortedParameterIds.forEach(id => {
+			const p = parameters.get(id);
+			if (p) set.add(p);
+		});
+	});
+
+	return (
+		<Stack className={ classes.midiMappingsWrap } >
+			<MIDIMappedParameterList
+				patcherInstances={ patcherInstances }
+				parameters={ displayParameters }
+				onClearParameterMidiMapping={ onClearParameterMidiMapping }
+				onSort={ onSort }
+				sortAttr={ sortAttr }
+				sortOrder={ sortOrder }
+			/>
+		</Stack>
+	);
+};
+
+export default MIDIMappings;

--- a/src/pages/midimappings.tsx
+++ b/src/pages/midimappings.tsx
@@ -3,48 +3,27 @@ import { Stack } from "@mantine/core";
 import { useAppDispatch, useAppSelector } from "../hooks/useAppDispatch";
 import { RootStateType } from "../lib/store";
 import classes from "../components/midi/midi.module.css";
-import { MIDIMappedParameterSortAttr, SortOrder } from "../lib/constants";
+import { MIDIMappedParameterSortAttr, MIDIMetaMappingType, SortOrder } from "../lib/constants";
 import { useCallback, useEffect, useState } from "react";
 import { getPatcherInstanceParametersWithMIDIMapping, getPatcherInstancesByIndex } from "../selectors/patchers";
 import MIDIMappedParameterList from "../components/midi/mappedParameterList";
 import { ParameterRecord } from "../models/parameter";
-import { clearParameterMIDIMappingOnRemote, setParameterMIDIChannelOnRemote, setParameterMIDIControlOnRemote } from "../actions/patchers";
+import { clearParameterMIDIMappingOnRemote, setParameterMIDIMappingOnRemoteFromDisplayValue } from "../actions/patchers";
 import { PatcherInstanceRecord } from "../models/instance";
+import { formatMIDIMappingToDisplay } from "../lib/util";
 
-const collator = new Intl.Collator("en-US");
+const collator = new Intl.Collator("en-US", { numeric: true });
 const parameterComparators: Record<MIDIMappedParameterSortAttr, Record<SortOrder, (a: ParameterRecord, b: ParameterRecord) => number>> = {
-	[MIDIMappedParameterSortAttr.MIDIChannel]: {
+	[MIDIMappedParameterSortAttr.MIDISource]: {
 		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.meta.midi?.chan < b.meta.midi?.chan) return -1;
-			if (a.meta.midi?.chan > b.meta.midi?.chan) return 1;
-			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return -1;
-			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return 1;
-			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+			const aDisplay = formatMIDIMappingToDisplay(a.midiMappingType as MIDIMetaMappingType, a.meta.midi);
+			const bDisplay = formatMIDIMappingToDisplay(b.midiMappingType as MIDIMetaMappingType, b.meta.midi);
+			return collator.compare(aDisplay, bDisplay);
 		},
 		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.meta.midi?.chan > b.meta.midi?.chan) return -1;
-			if (a.meta.midi?.chan < b.meta.midi?.chan) return 1;
-			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return -1;
-			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return 1;
-
-			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
-		}
-	},
-	[MIDIMappedParameterSortAttr.MIDIControl]: {
-		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return -1;
-			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return 1;
-			if (a.meta.midi?.chan < b.meta.midi?.chan) return -1;
-			if (a.meta.midi?.chan > b.meta.midi?.chan) return 1;
-			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
-		},
-		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.meta.midi?.ctrl > b.meta.midi?.ctrl) return -1;
-			if (a.meta.midi?.ctrl < b.meta.midi?.ctrl) return 1;
-			if (a.meta.midi?.chan > b.meta.midi?.chan) return -1;
-			if (a.meta.midi?.chan < b.meta.midi?.chan) return 1;
-
-			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
+			const aDisplay = formatMIDIMappingToDisplay(a.midiMappingType as MIDIMetaMappingType, a.meta.midi);
+			const bDisplay = formatMIDIMappingToDisplay(b.midiMappingType as MIDIMetaMappingType, b.meta.midi);
+			return collator.compare(aDisplay, bDisplay) * -1;
 		}
 	},
 	[MIDIMappedParameterSortAttr.InstanceIndex]: {
@@ -76,7 +55,7 @@ const getSortedParameterIds = (params: ImmuMap<ParameterRecord["id"], ParameterR
 const MIDIMappings = () => {
 
 	const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.Asc);
-	const [sortAttr, setSortAttr] = useState<MIDIMappedParameterSortAttr>(MIDIMappedParameterSortAttr.MIDIChannel);
+	const [sortAttr, setSortAttr] = useState<MIDIMappedParameterSortAttr>(MIDIMappedParameterSortAttr.MIDISource);
 	const [sortedParameterIds, setSortedParameterIds] = useState<ImmuOrderedSet<ParameterRecord["id"]>>(ImmuOrderedSet<ParameterRecord["id"]>());
 
 	const dispatch = useAppDispatch();
@@ -92,12 +71,8 @@ const MIDIMappings = () => {
 		dispatch(clearParameterMIDIMappingOnRemote(instance.id, param.id));
 	}, [dispatch]);
 
-	const onUpdateParamterMIDIChannel = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => {
-		dispatch(setParameterMIDIChannelOnRemote(instance.id, param.id, channel));
-	}, [dispatch]);
-
-	const onUpdateParamterMIDIControl = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => {
-		dispatch(setParameterMIDIControlOnRemote(instance.id, param.id, control));
+	const onUpdateParameterMIDIMapping = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord, value: string) => {
+		dispatch(setParameterMIDIMappingOnRemoteFromDisplayValue(instance.id, param.id, value));
 	}, [dispatch]);
 
 	const onSort = useCallback((attr: MIDIMappedParameterSortAttr): void => {
@@ -125,8 +100,7 @@ const MIDIMappings = () => {
 				patcherInstances={ patcherInstances }
 				parameters={ displayParameters }
 				onClearParameterMIDIMapping={ onClearParameterMIDIMapping }
-				onUpdateParameterMIDIChannel={ onUpdateParamterMIDIChannel }
-				onUpdateParameterMIDIControl={ onUpdateParamterMIDIControl }
+				onUpdateParameterMIDIMapping={ onUpdateParameterMIDIMapping }
 				onSort={ onSort }
 				sortAttr={ sortAttr }
 				sortOrder={ sortOrder }

--- a/src/pages/midimappings.tsx
+++ b/src/pages/midimappings.tsx
@@ -93,7 +93,7 @@ const MIDIMappings = () => {
 	}, [dispatch]);
 
 	const onSort = useCallback((attr: MIDIMappedParameterSortAttr) => {
-		if (attr === sortAttr) return setSortOrder(sortOrder === SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc);
+		if (attr === sortAttr) return void setSortOrder(sortOrder === SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc);
 
 		setSortAttr(attr);
 		setSortOrder(SortOrder.Asc);

--- a/src/pages/midimappings.tsx
+++ b/src/pages/midimappings.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useState } from "react";
 import { getPatcherInstanceParametersWithMIDIMapping, getPatcherInstancesByIndex } from "../selectors/patchers";
 import MIDIMappedParameterList from "../components/midi/mappedParameterList";
 import { ParameterRecord } from "../models/parameter";
-import { clearParameterMidiMappingOnRemote } from "../actions/patchers";
+import { clearParameterMIDIMappingOnRemote, setParameterMIDIChannelOnRemote, setParameterMIDIControlOnRemote } from "../actions/patchers";
 import { PatcherInstanceRecord } from "../models/instance";
 
 const collator = new Intl.Collator("en-US");
@@ -88,11 +88,19 @@ const MIDIMappings = () => {
 		getPatcherInstanceParametersWithMIDIMapping(state)
 	]);
 
-	const onClearParameterMidiMapping = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord) => {
-		dispatch(clearParameterMidiMappingOnRemote(instance.id, param.id));
+	const onClearParameterMIDIMapping = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord) => {
+		dispatch(clearParameterMIDIMappingOnRemote(instance.id, param.id));
 	}, [dispatch]);
 
-	const onSort = useCallback((attr: MIDIMappedParameterSortAttr) => {
+	const onUpdateParamterMIDIChannel = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord, channel: number) => {
+		dispatch(setParameterMIDIChannelOnRemote(instance.id, param.id, channel));
+	}, [dispatch]);
+
+	const onUpdateParamterMIDIControl = useCallback((instance: PatcherInstanceRecord, param: ParameterRecord, control: number) => {
+		dispatch(setParameterMIDIControlOnRemote(instance.id, param.id, control));
+	}, [dispatch]);
+
+	const onSort = useCallback((attr: MIDIMappedParameterSortAttr): void => {
 		if (attr === sortAttr) return void setSortOrder(sortOrder === SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc);
 
 		setSortAttr(attr);
@@ -116,7 +124,9 @@ const MIDIMappings = () => {
 			<MIDIMappedParameterList
 				patcherInstances={ patcherInstances }
 				parameters={ displayParameters }
-				onClearParameterMidiMapping={ onClearParameterMidiMapping }
+				onClearParameterMIDIMapping={ onClearParameterMIDIMapping }
+				onUpdateParameterMIDIChannel={ onUpdateParamterMIDIChannel }
+				onUpdateParameterMIDIControl={ onUpdateParamterMIDIControl }
 				onSort={ onSort }
 				sortAttr={ sortAttr }
 				sortOrder={ sortOrder }

--- a/src/selectors/patchers.ts
+++ b/src/selectors/patchers.ts
@@ -152,7 +152,6 @@ export const getPatcherInstanceMessageInportsByInstanceIndex = createSelector(
 		(state: RootStateType, instanceIndex: PatcherInstanceRecord["index"]): PatcherInstanceRecord["index"] => instanceIndex
 	],
 	(ports, instanceIndex): ImmuMap<MessagePortRecord["id"], MessagePortRecord> => {
-		console.log(ports.valueSeq().toArray().map(p => p.toJSON()));
 		return ports.filter(p => {
 			return p.instanceIndex === instanceIndex;
 		});

--- a/src/selectors/patchers.ts
+++ b/src/selectors/patchers.ts
@@ -71,6 +71,15 @@ export const getPatcherInstancesByIndex = createSelector(
 
 export const getPatcherInstanceParameters = (state: RootStateType): ImmuMap<ParameterRecord["id"], ParameterRecord> => state.patchers.instanceParameters;
 
+export const getPatcherInstanceParametersWithMIDIMapping = createSelector(
+	[
+		getPatcherInstanceParameters
+	],
+	(parameters): ImmuMap<ParameterRecord["id"], ParameterRecord> => {
+		return parameters.filter(p => p.isMidiMapped);
+	}
+);
+
 export const getPatcherInstanceParameter = createSelector(
 	[
 		getPatcherInstanceParameters,


### PR DESCRIPTION
This adds a Global MIDI Mapping view. Currently it's read-only apart from clearing the mapping but should be relatively straightforward to make it possible to inline edit the MIDI Channel and CCs.

I've added a button to the left sidebar for now to access this view, reasonable?

Setting to draft for now until editing in place.

Closes #171 