### PR TITLE
Dropped instance.index usage in favour of referring to it simply as id

### DIFF
--- a/server.py
+++ b/server.py
@@ -45,8 +45,8 @@ class MyRequestHandler(SimpleHTTPRequestHandler):
 		normPath.remove('')
 
 		fpath = path.join(args.directory, '{os.sep}'.join(normPath))
-		# handle /instances/12 -> /instances/[index].html  mapping
-		ipath = path.join(normPath[0], "[index].html")
+		# handle /instances/12 -> /instances/[id].html  mapping
+		ipath = path.join(normPath[0], "[id].html")
 
 		if not path.isfile(fpath) and not fext and path.isfile(fpath + '.html'):
 			self.path = self.path + '.html'

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -11,7 +11,7 @@ import { oscQueryBridge } from "../controller/oscqueryBridgeController";
 import { isValidConnection } from "../lib/editorUtils";
 import throttle from "lodash.throttle";
 import { OSCQuerySetMeta } from "../lib/types";
-import { setConnection, setNode, setNodes, unloadPatcherNodeByIndexOnRemote } from "./graph";
+import { setConnection, setNode, setNodes, unloadPatcherNodeOnRemote } from "./graph";
 import { getGraphEditorInstance, getGraphEditorLockedState } from "../selectors/editor";
 import { defaultNodeGap } from "../lib/constants";
 
@@ -191,7 +191,7 @@ export const removeEditorNodeById = (id: GraphNode["id"], updateSetMeta = true):
 				throw new Error(`System nodes cannot be removed (id: ${id}).`);
 			}
 
-			dispatch(unloadPatcherNodeByIndexOnRemote(node.index));
+			dispatch(unloadPatcherNodeOnRemote(node.instanceId));
 			if (updateSetMeta) doUpdateNodesMeta(getNodes(state).delete(node.id));
 
 		} catch (err) {

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -714,7 +714,7 @@ export const removePatcherNode = (instanceId: string): AppThunk =>
 			if (node?.type !== NodeType.Patcher) return;
 			dispatch(deleteNode(node));
 
-			const instance = getPatcherInstance(state, node.id);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 			dispatch(deleteInstance(instance));

--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -4,7 +4,7 @@ import { oscQueryBridge } from "../controller/oscqueryBridgeController";
 import { ActionBase, AppThunk, RootStateType } from "../lib/store";
 import { OSCQueryRNBOInstance, OSCQueryRNBOInstancesState, OSCQueryRNBOJackConnections, OSCQueryRNBOJackPortInfo, OSCQuerySetMeta, OSCQuerySetNodeMeta } from "../lib/types";
 import { ConnectionType, GraphConnectionRecord, GraphControlNodeRecord, GraphNodeRecord, GraphPatcherNodeRecord, GraphPortRecord, GraphSystemNodeRecord, NodeType, PortDirection, calculateNodeContentHeight, createNodePorts } from "../models/graph";
-import { getConnectionsForSourceNodeAndPort, getNode, getPatcherNodeByIndex, getNodes, getSystemNodeByJackNameAndDirection, getConnections, getPatcherNodes, getSystemNodes, getControlNodes } from "../selectors/graph";
+import { getConnectionsForSourceNodeAndPort, getNode, getPatcherNodeByInstanceId, getNodes, getSystemNodeByJackNameAndDirection, getConnections, getPatcherNodes, getSystemNodes, getControlNodes } from "../selectors/graph";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { PatcherInstanceRecord } from "../models/instance";
@@ -362,9 +362,9 @@ export const initNodes = (jackPortsInfo: OSCQueryRNBOJackPortInfo, instanceInfo:
 			patcherAndControlNodes.push(node);
 			const instance = PatcherInstanceRecord.fromDescription(info);
 			instances.push(instance);
-			instanceParameters.push(...ParameterRecord.fromDescription(instance.index, info.CONTENTS.params));
-			instanceMessageInports.push(...MessagePortRecord.fromDescription(instance.index, info.CONTENTS.messages?.CONTENTS?.in));
-			instanceMessageOutports.push(...MessagePortRecord.fromDescription(instance.index, info.CONTENTS.messages?.CONTENTS?.out));
+			instanceParameters.push(...ParameterRecord.fromDescription(instance.id, info.CONTENTS.params));
+			instanceMessageInports.push(...MessagePortRecord.fromDescription(instance.id, info.CONTENTS.messages?.CONTENTS?.in));
+			instanceMessageOutports.push(...MessagePortRecord.fromDescription(instance.id, info.CONTENTS.messages?.CONTENTS?.out));
 		}
 
 		// Build a list of all Jack generated names that have not been used for PatcherNodes above
@@ -607,14 +607,14 @@ export const updateSystemOrControlPortInfo = (type: ConnectionType, direction: P
 	};
 
 // Trigger Updates on remote OSCQuery Runner
-export const unloadPatcherNodeByIndexOnRemote = (instanceIndex: number): AppThunk =>
+export const unloadPatcherNodeOnRemote = (instanceId: string): AppThunk =>
 	(dispatch) => {
 		try {
 
 			const message = {
 				address: "/rnbo/inst/control/unload",
 				args: [
-					{ type: "i", value: instanceIndex }
+					{ type: "i", value: parseInt(instanceId, 10) }
 				]
 			};
 			oscQueryBridge.sendPacket(writePacket(message));
@@ -695,9 +695,9 @@ export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): 
 
 		// Create Instance State
 		const instance = PatcherInstanceRecord.fromDescription(desc);
-		const parameters = ParameterRecord.fromDescription(instance.index, desc.CONTENTS.params);
-		const messageInports = MessagePortRecord.fromDescription(instance.index, desc.CONTENTS.messages?.CONTENTS?.in);
-		const messageOutports = MessagePortRecord.fromDescription(instance.index, desc.CONTENTS.messages?.CONTENTS?.out);
+		const parameters = ParameterRecord.fromDescription(instance.id, desc.CONTENTS.params);
+		const messageInports = MessagePortRecord.fromDescription(instance.id, desc.CONTENTS.messages?.CONTENTS?.in);
+		const messageOutports = MessagePortRecord.fromDescription(instance.id, desc.CONTENTS.messages?.CONTENTS?.out);
 
 		dispatch(setInstance(instance));
 		dispatch(setInstanceParameters(parameters));
@@ -705,12 +705,12 @@ export const addPatcherNode = (desc: OSCQueryRNBOInstance, metaString: string): 
 		dispatch(setInstanceMessageOutports(messageOutports));
 	};
 
-export const removePatcherNode = (index: number): AppThunk =>
+export const removePatcherNode = (instanceId: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
 
-			const node = getPatcherNodeByIndex(state, index);
+			const node = getPatcherNodeByInstanceId(state, instanceId);
 			if (node?.type !== NodeType.Patcher) return;
 			dispatch(deleteNode(node));
 

--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -2,7 +2,7 @@ import Router from "next/router";
 import { ActionBase, AppThunk } from "../lib/store";
 import { MIDIMetaMapping, OSCQueryRNBOInstance, OSCQueryRNBOInstancePresetEntries, OSCQueryRNBOPatchersState, OSCValue, ParameterMetaJsonMap } from "../lib/types";
 import { PatcherInstanceRecord } from "../models/instance";
-import { getPatcherInstanceByIndex, getPatcherInstance, getPatcherInstanceParametersByInstanceIndex, getPatcherInstanceMessageInportsByInstanceIndex, getPatcherInstanceMesssageOutportsByInstanceIndex, getPatcherInstanceMessageInportByPath, getPatcherInstanceMessageOutportByPath, getPatcherInstanceMesssageOutportsByInstanceIndexAndTag, getPatcherInstanceParameterByPath, getPatcherInstanceParametersByInstanceIndexAndName, getPatcherInstanceMessageInportsByInstanceIndexAndTag } from "../selectors/patchers";
+import { getPatcherInstance, getPatcherInstanceParametersByInstanceId, getPatcherInstanceMessageInportsByInstanceId, getPatcherInstanceMesssageOutportsByInstanceId, getPatcherInstanceMessageInportByPath, getPatcherInstanceMessageOutportByPath, getPatcherInstanceMesssageOutportsByInstanceIdAndTag, getPatcherInstanceParameterByPath, getPatcherInstanceParametersByInstanceIdAndName, getPatcherInstanceMessageInportsByInstanceIdAndTag } from "../selectors/patchers";
 import { getAppSetting } from "../selectors/settings";
 import { ParameterRecord } from "../models/parameter";
 import { MessagePortRecord } from "../models/messageport";
@@ -455,7 +455,7 @@ export const sendInstanceMessageToRemote = (instance: PatcherInstanceRecord, inp
 
 
 		const message = {
-			address: `/rnbo/inst/${instance.index}/messages/in/${inportId}`,
+			address: `/rnbo/inst/${instance.id}/messages/in/${inportId}`,
 			args: values
 		};
 		oscQueryBridge.sendPacket(writePacket(message));
@@ -547,7 +547,7 @@ export const activateParameterMIDIMappingFocus = (param: ParameterRecord): AppTh
 	(dispatch, getState) => {
 
 		const state = getState();
-		const params = getPatcherInstanceParametersByInstanceIndex(state, param.instanceIndex);
+		const params = getPatcherInstanceParametersByInstanceId(state, param.instanceId);
 
 		dispatch(setInstanceParameters(
 			params.valueSeq().toArray().map(p => p.setWaitingForMidiMapping(p.id === param.id))
@@ -640,11 +640,11 @@ export const restoreDefaultMessagePortMetaOnRemote = (_instance: PatcherInstance
 	};
 
 // Updates in response to remote OSCQuery Updates
-export const updateInstancePresetEntries = (index: number, entries: OSCQueryRNBOInstancePresetEntries): AppThunk =>
+export const updateInstancePresetEntries = (instanceId: string, entries: OSCQueryRNBOInstancePresetEntries): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 			dispatch(setInstance(instance.updatePresets(entries)));
@@ -653,11 +653,11 @@ export const updateInstancePresetEntries = (index: number, entries: OSCQueryRNBO
 		}
 	};
 
-export const updateInstancePresetLatest = (index: number, name: string): AppThunk =>
+export const updateInstancePresetLatest = (instanceId: string, name: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 			dispatch(setInstance(instance.setPresetLatest(name)));
@@ -666,11 +666,11 @@ export const updateInstancePresetLatest = (index: number, name: string): AppThun
 		}
 	};
 
-export const updateInstancePresetInitial = (index: number, name: string): AppThunk =>
+export const updateInstancePresetInitial = (instanceId: string, name: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 			dispatch(setInstance(instance.setPresetInitial(name)));
@@ -679,22 +679,22 @@ export const updateInstancePresetInitial = (index: number, name: string): AppThu
 		}
 	};
 
-export const updateInstanceMessages = (index: number, desc: OSCQueryRNBOInstance["CONTENTS"]["messages"]): AppThunk =>
+export const updateInstanceMessages = (instanceId: string, desc: OSCQueryRNBOInstance["CONTENTS"]["messages"]): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			if (!desc) return;
 
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
-			const currentMessageInports = getPatcherInstanceMessageInportsByInstanceIndex(state, instance.index);
-			const currentMessageOutports = getPatcherInstanceMesssageOutportsByInstanceIndex(state, instance.index);
+			const currentMessageInports = getPatcherInstanceMessageInportsByInstanceId(state, instance.id);
+			const currentMessageOutports = getPatcherInstanceMesssageOutportsByInstanceId(state, instance.id);
 			dispatch(deleteInstanceMessageInports(currentMessageInports.valueSeq().toArray()));
 			dispatch(deleteInstanceMessageOutports(currentMessageOutports.valueSeq().toArray()));
 
-			const messageInports = MessagePortRecord.fromDescription(instance.index, desc.CONTENTS?.in);
-			const messageOutports = MessagePortRecord.fromDescription(instance.index, desc.CONTENTS?.out);
+			const messageInports = MessagePortRecord.fromDescription(instance.id, desc.CONTENTS?.in);
+			const messageOutports = MessagePortRecord.fromDescription(instance.id, desc.CONTENTS?.out);
 
 			dispatch(setInstanceMessageInports(messageInports));
 			dispatch(setInstanceMessageOutports(messageOutports));
@@ -730,7 +730,7 @@ export const removeInstanceMessageOutportByPath = (path: string): AppThunk =>
 		}
 	};
 
-export const updateInstanceMessageOutportValue = (index: number, tag: MessagePortRecord["tag"], value: OSCValue | OSCValue[]): AppThunk =>
+export const updateInstanceMessageOutportValue = (instanceId: string, tag: MessagePortRecord["tag"], value: OSCValue | OSCValue[]): AppThunk =>
 	(dispatch, getState) => {
 		try {
 
@@ -741,12 +741,12 @@ export const updateInstanceMessageOutportValue = (index: number, tag: MessagePor
 			if (!enabled) return;
 
 			// Active Instance view?!
-			if (Router.pathname !== "/instances/[index]" || Router.query.index !== `${index}`) return;
+			if (Router.pathname !== "/instances/[index]" || Router.query.index !== `${instanceId}`) return;
 
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
-			const port = getPatcherInstanceMesssageOutportsByInstanceIndexAndTag(state, instance.index, tag);
+			const port = getPatcherInstanceMesssageOutportsByInstanceIdAndTag(state, instance.id, tag);
 			if (!port) return;
 
 			dispatch(setInstanceMessageOutport(port.setValue(Array.isArray(value) ? value.join(", ") : `${value}`)));
@@ -768,31 +768,31 @@ export const removeInstanceParameterByPath = (path: string): AppThunk =>
 		}
 	};
 
-export const updateInstanceParameters = (index: number, desc: OSCQueryRNBOInstance["CONTENTS"]["params"]): AppThunk =>
+export const updateInstanceParameters = (instanceId: string, desc: OSCQueryRNBOInstance["CONTENTS"]["params"]): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			if (!desc) return;
 
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
-			const currentParams = getPatcherInstanceParametersByInstanceIndex(state, instance.index);
+			const currentParams = getPatcherInstanceParametersByInstanceId(state, instance.id);
 			dispatch(deleteInstanceParameters(currentParams.valueSeq().toArray()));
 
-			const newParams = ParameterRecord.fromDescription(instance.index, desc);
+			const newParams = ParameterRecord.fromDescription(instance.id, desc);
 			dispatch(setInstanceParameters(newParams));
 		} catch (e) {
 			console.log(e);
 		}
 	};
 
-export const updateInstanceDataRefValue = (index: number, name: string, value: string): AppThunk =>
+export const updateInstanceDataRefValue = (instanceId: string, name: string, value: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
 
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 			dispatch(setInstance(
@@ -803,11 +803,11 @@ export const updateInstanceDataRefValue = (index: number, name: string, value: s
 		}
 	};
 
-export const updateInstanceParameterValue = (index: number, name: ParameterRecord["name"], value: number): AppThunk =>
+export const updateInstanceParameterValue = (instanceId: string, name: ParameterRecord["name"], value: number): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const param = getPatcherInstanceParametersByInstanceIndexAndName(state, index, name);
+			const param = getPatcherInstanceParametersByInstanceIdAndName(state, instanceId, name);
 			if (!param) return;
 
 			dispatch(setInstanceParameter(param.setValue(value)));
@@ -816,11 +816,11 @@ export const updateInstanceParameterValue = (index: number, name: ParameterRecor
 		}
 	};
 
-export const updateInstanceParameterValueNormalized = (index: number, name: ParameterRecord["name"], value: number): AppThunk =>
+export const updateInstanceParameterValueNormalized = (instanceId: string, name: ParameterRecord["name"], value: number): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const param = getPatcherInstanceParametersByInstanceIndexAndName(state, index, name);
+			const param = getPatcherInstanceParametersByInstanceIdAndName(state, instanceId, name);
 			if (!param) return;
 
 			dispatch(setInstanceParameter(param.setNormalizedValue(value)));
@@ -837,7 +837,7 @@ export const setInstanceWaitingForMidiMappingOnRemote = (id: PatcherInstanceReco
 			if (!instance) return;
 
 			dispatch(setInstance(instance.setWaitingForMapping(value)));
-			const params = getPatcherInstanceParametersByInstanceIndex(state, instance.index).valueSeq().map(p => p.setWaitingForMidiMapping(false));
+			const params = getPatcherInstanceParametersByInstanceId(state, instance.id).valueSeq().map(p => p.setWaitingForMidiMapping(false));
 			dispatch(setInstanceParameters(params.toArray()));
 
 			try {
@@ -861,34 +861,34 @@ export const setInstanceWaitingForMidiMappingOnRemote = (id: PatcherInstanceReco
 		}
 	};
 
-export const updateInstanceMIDIReport = (index: number, value: boolean): AppThunk =>
+export const updateInstanceMIDIReport = (instanceId: string, value: boolean): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 			dispatch(setInstance(instance.setWaitingForMapping(value)));
-			const params = getPatcherInstanceParametersByInstanceIndex(state, instance.index).valueSeq().map(p => p.setWaitingForMidiMapping(false));
+			const params = getPatcherInstanceParametersByInstanceId(state, instance.id).valueSeq().map(p => p.setWaitingForMidiMapping(false));
 			dispatch(setInstanceParameters(params.toArray()));
 		} catch (e) {
 			console.log(e);
 		}
 	};
 
-export const updateInstanceMIDILastValue = (index: number, value: string): AppThunk =>
+export const updateInstanceMIDILastValue = (instanceId: string, value: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 
 			const state = getState();
 
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance?.waitingForMidiMapping) return;
 
 			const midiMeta = JSON.parse(value);
 
 			// find waiting, update their meta, set them no longer waiting and update map
 			const parameters: ParameterRecord[] = [];
-			getPatcherInstanceParametersByInstanceIndex(state, instance.index).forEach(param => {
+			getPatcherInstanceParametersByInstanceId(state, instance.id).forEach(param => {
 				if (param.waitingForMidiMapping) {
 					const meta = cloneJSON(param.meta);
 					meta.midi = midiMeta;
@@ -912,11 +912,11 @@ export const updateInstanceMIDILastValue = (index: number, value: string): AppTh
 		}
 	};
 
-export const updateInstanceParameterMeta = (index: number, name: ParameterRecord["name"], value: string): AppThunk =>
+export const updateInstanceParameterMeta = (instanceId: string, name: ParameterRecord["name"], value: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const param = getPatcherInstanceParametersByInstanceIndexAndName(state, index, name);
+			const param = getPatcherInstanceParametersByInstanceIdAndName(state, instanceId, name);
 			if (!param) return;
 
 			dispatch(setInstanceParameter(param.setMeta(value)));
@@ -925,15 +925,15 @@ export const updateInstanceParameterMeta = (index: number, name: ParameterRecord
 		}
 	};
 
-export const updateInstanceMessageOutportMeta = (index: number, tag: MessagePortRecord["tag"], value: string): AppThunk =>
+export const updateInstanceMessageOutportMeta = (instanceId: string, tag: MessagePortRecord["tag"], value: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
 
-			const port = getPatcherInstanceMessageInportsByInstanceIndexAndTag(state, instance.index, tag);
+			const port = getPatcherInstanceMessageInportsByInstanceIdAndTag(state, instance.id, tag);
 			if (!port) return;
 
 			dispatch(setInstanceMessageOutport(port.setMeta(value)));
@@ -942,14 +942,14 @@ export const updateInstanceMessageOutportMeta = (index: number, tag: MessagePort
 		}
 	};
 
-export const updateInstanceMessageInportMeta = (index: number, tag: MessagePortRecord["tag"], value: string): AppThunk =>
+export const updateInstanceMessageInportMeta = (instanceId: string, tag: MessagePortRecord["tag"], value: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const instance = getPatcherInstanceByIndex(state, index);
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;
 
-			const port = getPatcherInstanceMessageInportsByInstanceIndexAndTag(state, instance.index, tag);
+			const port = getPatcherInstanceMessageInportsByInstanceIdAndTag(state, instance.id, tag);
 			if (!port) return;
 
 			dispatch(setInstanceMessageInport(port.setMeta(value)));
@@ -957,5 +957,3 @@ export const updateInstanceMessageInportMeta = (index: number, tag: MessagePortR
 			console.log(e);
 		}
 	};
-
-// Events from remote

--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -741,7 +741,7 @@ export const updateInstanceMessageOutportValue = (instanceId: string, tag: Messa
 			if (!enabled) return;
 
 			// Active Instance view?!
-			if (Router.pathname !== "/instances/[index]" || Router.query.index !== `${instanceId}`) return;
+			if (Router.pathname !== "/instances/[id]" || Router.query.id !== `${instanceId}`) return;
 
 			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) return;

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -6,7 +6,7 @@ import { PresetRecord } from "../models/preset";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { ParameterRecord } from "../models/parameter";
-import { getPatcherInstanceByIndex, getPatcherInstanceParamtersSortedByIndex } from "../selectors/patchers";
+import { getPatcherInstance, getPatcherInstanceParamtersSortedByInstanceIdAndIndex } from "../selectors/patchers";
 import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewListState } from "../lib/types";
 import { getGraphSetView, getGraphSetViews } from "../selectors/sets";
 import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry } from "../lib/util";
@@ -333,7 +333,7 @@ export const createSetViewOnRemote = (givenName: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const params = getPatcherInstanceParamtersSortedByIndex(state);
+			const params = getPatcherInstanceParamtersSortedByInstanceIdAndIndex(state);
 			const existingViews = getGraphSetViews(state);
 			const name = getUniqueName(givenName, existingViews.valueSeq().map(v => v.name).toArray());
 
@@ -473,15 +473,15 @@ export const updateSetViewParameterListOnRemote = (setView: GraphSetViewRecord, 
 export const offsetParameterIndexInSetView = (setView: GraphSetViewRecord, param: ParameterRecord, offset: number): AppThunk =>
 	(dispatch) => {
 		try {
-			const currentIndex = setView.params.findIndex(entry => entry.instanceIndex === param.instanceIndex && entry.paramIndex === param.index);
+			const currentIndex = setView.params.findIndex(entry => entry.instanceId === param.instanceId && entry.paramIndex === param.index);
 			const newIndex = clamp(currentIndex + offset, 0, setView.params.size - 1);
 
 			const newList = setView.params
 				.delete(currentIndex)
-				.insert(newIndex, { instanceIndex: param.instanceIndex, paramIndex: param.index });
+				.insert(newIndex, { instanceId: param.instanceId, paramIndex: param.index });
 			const message = {
 				address: `/rnbo/inst/control/sets/views/list/${setView.id}/params`,
-				args: newList.toArray().map(p => ({ type: "s", value: instanceAndParamIndicesToSetViewEntry(p.instanceIndex, p.paramIndex) }))
+				args: newList.toArray().map(p => ({ type: "s", value: instanceAndParamIndicesToSetViewEntry(p.instanceId, p.paramIndex) }))
 			};
 			oscQueryBridge.sendPacket(writePacket(message));
 		} catch (err) {
@@ -550,7 +550,7 @@ export const addParameterToSetView = (setView: GraphSetViewRecord, param: Parame
 		try {
 			if (setView.paramIds.has(param.setViewId)) return;
 			const params = setView.paramIds.toArray().map(pId => ({ type: "s", value: pId }));
-			params.push({ type: "s", value: instanceAndParamIndicesToSetViewEntry(param.instanceIndex, param.index) });
+			params.push({ type: "s", value: instanceAndParamIndicesToSetViewEntry(param.instanceId, param.index) });
 
 			const message = {
 				address: `/rnbo/inst/control/sets/views/list/${setView.id}/params`,
@@ -572,10 +572,10 @@ export const addAllParamtersToSetView = (setView: GraphSetViewRecord): AppThunk 
 		try {
 			const state = getState();
 			const params = setView.params.withMutations(list => {
-				getPatcherInstanceParamtersSortedByIndex(state)
+				getPatcherInstanceParamtersSortedByInstanceIdAndIndex(state)
 					.forEach(param => {
 						if (!setView.paramIds.has(param.setViewId)) {
-							list.push({ instanceIndex: param.instanceIndex, paramIndex: param.index });
+							list.push({ instanceId: param.instanceId, paramIndex: param.index });
 						}
 					});
 			}).toArray();
@@ -583,7 +583,7 @@ export const addAllParamtersToSetView = (setView: GraphSetViewRecord): AppThunk 
 
 			const message = {
 				address: `/rnbo/inst/control/sets/views/list/${setView.id}/params`,
-				args: params.map(p => ({ type: "s", value: instanceAndParamIndicesToSetViewEntry(p.instanceIndex, p.paramIndex) }))
+				args: params.map(p => ({ type: "s", value: instanceAndParamIndicesToSetViewEntry(p.instanceId, p.paramIndex) }))
 			};
 			oscQueryBridge.sendPacket(writePacket(message));
 		} catch (err) {
@@ -638,10 +638,10 @@ export const setViewContainedInstancesWaitingForMidiMappingOnRemote = (setView: 
 	(dispatch, getState) => {
 
 		const state = getState();
-		const instanceIndices = setView.instanceIndices.toArray();
+		const ids = setView.instanceIds.toArray();
 
-		for (const index of instanceIndices) {
-			const instance = getPatcherInstanceByIndex(state, index);
+		for (const instanceId of ids) {
+			const instance = getPatcherInstance(state, instanceId);
 			if (!instance) continue;
 			dispatch(setInstanceWaitingForMidiMappingOnRemote(instance.id, value));
 		}

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -85,7 +85,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 
 	const onNodeDoubleClick = useCallback((e: React.MouseEvent, node: Node<NodeDataProps>) => {
 		if (node.type !== NodeType.Patcher) return;
-		push({ pathname: "/instances/[index]", query: { ...query, index: (node.data.node as GraphPatcherNodeRecord).index }});
+		push({ pathname: "/instances/[index]", query: { ...query, index: (node.data.node as GraphPatcherNodeRecord).instanceId }});
 	}, [query, push]);
 
 	const flowNodes: Node<NodeDataProps>[] = nodes.valueSeq().toArray().map(node => ({

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -85,7 +85,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 
 	const onNodeDoubleClick = useCallback((e: React.MouseEvent, node: Node<NodeDataProps>) => {
 		if (node.type !== NodeType.Patcher) return;
-		push({ pathname: "/instances/[index]", query: { ...query, index: (node.data.node as GraphPatcherNodeRecord).instanceId }});
+		push({ pathname: "/instances/[id]", query: { ...query, id: (node.data.node as GraphPatcherNodeRecord).instanceId }});
 	}, [query, push]);
 
 	const flowNodes: Node<NodeDataProps>[] = nodes.valueSeq().toArray().map(node => ({

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -31,7 +31,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 					<Tooltip label="Open Patcher Instance Control">
 						<ActionIcon
 							component={ Link }
-							href={{ pathname: "/instances/[index]", query: { ...query, index: (node as GraphPatcherNodeRecord).index } }}
+							href={{ pathname: "/instances/[index]", query: { ...query, index: (node as GraphPatcherNodeRecord).instanceId } }}
 							size="md"
 							variant="transparent"
 						>

--- a/src/components/editor/patcherNode.tsx
+++ b/src/components/editor/patcherNode.tsx
@@ -31,7 +31,7 @@ const EditorPatcherNode: FunctionComponent<EditorNodeProps> = memo(function Wrap
 					<Tooltip label="Open Patcher Instance Control">
 						<ActionIcon
 							component={ Link }
-							href={{ pathname: "/instances/[index]", query: { ...query, index: (node as GraphPatcherNodeRecord).instanceId } }}
+							href={{ pathname: "/instances/[id]", query: { ...query, id: (node as GraphPatcherNodeRecord).instanceId } }}
 							size="md"
 							variant="transparent"
 						>

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -81,7 +81,7 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 			/>
 			<Table.Td className={ classes.parameterNameColumn } >{ param.name }</Table.Td>
 			<Table.Td className={ classes.patcherInstanceColumn } >
-				<span className={ classes.patcherInstanceIndex } >{ instance.index }</span>
+				<span className={ classes.patcherInstanceIndex } >{ instance.id }</span>
 				<span className={ classes.patcherInstanceName } >: {instance.name}</span>
 			</Table.Td>
 			<Table.Td className={ classes.parameterValueColumn } >{ formatParamValueForDisplay(param.value) }</Table.Td>
@@ -100,7 +100,7 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 							<Menu.Item
 								leftSection={ <IconElement path={ mdiVectorSquare } /> }
 								component={ Link }
-								href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instance.index } }}
+								href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instance.id } }}
 							>
 								Show Instance
 							</Menu.Item>

--- a/src/components/midi/mappedParameterItem.tsx
+++ b/src/components/midi/mappedParameterItem.tsx
@@ -100,7 +100,7 @@ const MIDIMappedParameter: FC<MIDIMappedParamProps> = memo(function WrappedMIDIM
 							<Menu.Item
 								leftSection={ <IconElement path={ mdiVectorSquare } /> }
 								component={ Link }
-								href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instance.id } }}
+								href={{ pathname: "/instances/[id]", query: { ...restQuery, id: instance.id } }}
 							>
 								Show Instance
 							</Menu.Item>

--- a/src/components/midi/mappedParameterList.tsx
+++ b/src/components/midi/mappedParameterList.tsx
@@ -10,7 +10,7 @@ import { MIDIMappedParameterSortAttr, SortOrder } from "../../lib/constants";
 
 export type MIDIMappedParameterListProps = {
 	parameters: ImmuOrderedSet<ParameterRecord>;
-	patcherInstances: ImmuMap<PatcherInstanceRecord["index"], PatcherInstanceRecord>;
+	patcherInstances: ImmuMap<PatcherInstanceRecord["id"], PatcherInstanceRecord>;
 	onClearParameterMIDIMapping: (param: ParameterRecord) => void;
 	onUpdateParameterMIDIMapping: (param: ParameterRecord, value: string) => void;
 	onSort: (sortAttr: MIDIMappedParameterSortAttr) => void;
@@ -56,9 +56,9 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 						className={ classes.patcherInstanceColumnHeader }
 						fz="xs"
 						onSort={ onSort }
-						sortKey={ MIDIMappedParameterSortAttr.InstanceIndex }
+						sortKey={ MIDIMappedParameterSortAttr.InstanceId }
 						sortOrder={ sortOrder }
-						sorted={ sortAttr === MIDIMappedParameterSortAttr.InstanceIndex }
+						sorted={ sortAttr === MIDIMappedParameterSortAttr.InstanceId }
 					>
 						Instance
 					</TableHeaderCell>
@@ -71,7 +71,7 @@ const MIDIMappedParameterList: FC<MIDIMappedParameterListProps> = memo(function 
 			<Table.Tbody>
 				{
 					parameters.map(p => {
-						const pInstance = patcherInstances.get(p.instanceIndex);
+						const pInstance = patcherInstances.get(p.instanceId);
 						if (!pInstance) return null;
 						return (
 							<MIDIMappedParameter

--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -8,7 +8,7 @@ import { RootStateType } from "../../lib/store";
 import { getShowSettingsModal } from "../../selectors/settings";
 import { ExternalNavLink, NavLink } from "./link";
 import { useRouter } from "next/router";
-import { getFirstPatcherNodeIndex } from "../../selectors/graph";
+import { getFirstPatcherNodeId } from "../../selectors/graph";
 import { mdiChartSankeyVariant, mdiCog, mdiFileMusic, mdiHelpCircle, mdiMidiPort, mdiVectorSquare, mdiTableEye } from "@mdi/js";
 
 const AppNav: FunctionComponent = memo(function WrappedNav() {
@@ -19,10 +19,10 @@ const AppNav: FunctionComponent = memo(function WrappedNav() {
 	const onToggleSettings = useCallback(() => dispatch(toggleShowSettings()), [dispatch]);
 	const [
 		settingsAreShown,
-		instanceIndex
+		instanceId
 	] = useAppSelector((state: RootStateType) => [
 		getShowSettingsModal(state),
-		getFirstPatcherNodeIndex(state)
+		getFirstPatcherNodeId(state)
 	]);
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,10 +39,10 @@ const AppNav: FunctionComponent = memo(function WrappedNav() {
 						isActive={ pathname === "/" }
 					/>
 					<NavLink
-						disabled={ instanceIndex === undefined }
+						disabled={ instanceId === undefined }
 						icon={ mdiVectorSquare }
 						label="Patcher Instance Control"
-						href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instanceIndex } }}
+						href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instanceId } }}
 						isActive={ pathname === "/instances/[index]" }
 					/>
 					<NavLink

--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -26,7 +26,7 @@ const AppNav: FunctionComponent = memo(function WrappedNav() {
 	]);
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { index, ...restQuery } = query; // slurp out potential index query element for a clean query
+	const { id, ...restQuery } = query; // slurp out potential id query element for a clean query
 
 	return (
 		<AppShell.Navbar>
@@ -42,8 +42,8 @@ const AppNav: FunctionComponent = memo(function WrappedNav() {
 						disabled={ instanceId === undefined }
 						icon={ mdiVectorSquare }
 						label="Patcher Instance Control"
-						href={{ pathname: "/instances/[index]", query: { ...restQuery, index: instanceId } }}
-						isActive={ pathname === "/instances/[index]" }
+						href={{ pathname: "/instances/[id]", query: { ...restQuery, id: instanceId } }}
+						isActive={ pathname === "/instances/[id]" }
 					/>
 					<NavLink
 						icon={ mdiFileMusic }

--- a/src/components/parameter/withSetViewActions.tsx
+++ b/src/components/parameter/withSetViewActions.tsx
@@ -42,7 +42,7 @@ export function withParameterSetViewActions(
 
 		return (
 			<WrappedComponent
-				displayName={ `${param.instanceIndex}: ${displayName || param.name}` }
+				displayName={ `${param.instanceId}: ${displayName || param.name}` }
 				index={ index }
 				param={ param }
 				{ ...props }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -73,7 +73,7 @@ export enum SortOrder {
 
 export enum MIDIMappedParameterSortAttr {
 	MIDISource = "midi_source",
-	InstanceIndex = "instance_index",
+	InstanceId = "instance_id",
 	ParameterName = "param_name"
 }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -77,7 +77,7 @@ export const formatParamValueForDisplay = (value: number | string) => {
 	return value;
 };
 
-export const instanceAndParamIndicesToSetViewEntry = (instanceIndex: number, paramIndex: number) => `${instanceIndex}:${paramIndex}`;
+export const instanceAndParamIndicesToSetViewEntry = (instanceId: string, paramIndex: number) => `${instanceId}:${paramIndex}`;
 
 export const cloneJSON = (value: JsonMap): JsonMap => JSON.parse(JSON.stringify(value));
 

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -64,7 +64,7 @@ export type GraphSystemNodeProps = CommonGraphNodeProps & {
 }
 
 export type GraphPatcherNodeProps = CommonGraphNodeProps & {
-	index: number;
+	instanceId: string;
 	patcher: string;
 	path: string;
 }
@@ -92,7 +92,7 @@ export interface GraphControlNode extends GraphNode {
 
 export class GraphPatcherNodeRecord extends ImmuRecord<GraphPatcherNodeProps>({
 
-	index: 0,
+	instanceId: "0",
 	jackName: "",
 	patcher: "",
 	path: "",
@@ -113,7 +113,7 @@ export class GraphPatcherNodeRecord extends ImmuRecord<GraphPatcherNodeProps>({
 	}
 
 	public get displayName(): string {
-		return `${this.index}: ${this.patcher}`;
+		return `${this.instanceId}: ${this.patcher}`;
 	}
 
 	public get id(): string {
@@ -215,7 +215,7 @@ export class GraphPatcherNodeRecord extends ImmuRecord<GraphPatcherNodeProps>({
 		const ports = this.portsFromDescription(desc.CONTENTS.jack);
 
 		return new GraphPatcherNodeRecord({
-			index: parseInt(desc.FULL_PATH.split("/").pop(), 10),
+			instanceId: desc.FULL_PATH.split("/").pop(),
 			jackName: this.getJackName(desc.CONTENTS.jack),
 			patcher: desc.CONTENTS.name.VALUE,
 			path: desc.FULL_PATH,

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -4,7 +4,7 @@ import { DataRefRecord } from "./dataref";
 import { OSCQueryRNBOInstance, OSCQueryRNBOInstancePresetEntries } from "../lib/types";
 
 export type PatcherInstanceProps = {
-	index: number;
+	id: string;
 	patcher: string;
 	path: string;
 	name: string;
@@ -32,7 +32,7 @@ function sortPresets(left: PresetRecord, right: PresetRecord) : number {
 
 export class PatcherInstanceRecord extends ImmuRecord<PatcherInstanceProps>({
 
-	index: 0,
+	id: "0",
 	name: "",
 	patcher: "",
 	path: "",
@@ -46,11 +46,7 @@ export class PatcherInstanceRecord extends ImmuRecord<PatcherInstanceProps>({
 }) {
 
 	public get displayName(): string {
-		return `${this.index}: ${this.name}`;
-	}
-
-	public get id(): string {
-		return this.name;
+		return `${this.id}: ${this.name}`;
 	}
 
 	public setWaitingForMapping(value: boolean): PatcherInstanceRecord {
@@ -104,7 +100,7 @@ export class PatcherInstanceRecord extends ImmuRecord<PatcherInstanceProps>({
 		const latestPreset: string = desc.CONTENTS.presets.CONTENTS?.loaded?.VALUE || "";
 
 		return new PatcherInstanceRecord({
-			index: parseInt(desc.FULL_PATH.split("/").pop(), 10),
+			id: desc.FULL_PATH.split("/").pop(),
 			name: this.getJackName(desc.CONTENTS.jack),
 			patcher: desc.CONTENTS.name.VALUE,
 			path: desc.FULL_PATH,

--- a/src/models/messageport.ts
+++ b/src/models/messageport.ts
@@ -4,7 +4,7 @@ import { PatcherInstanceRecord } from "./instance";
 import { parseMetaJSONString } from "../lib/util";
 
 export type MessagePortRecordProps = {
-	instanceIndex: number;
+	instanceId: string;
 	tag: string;
 	meta: JsonMap;
 	metaString: string;
@@ -14,7 +14,7 @@ export type MessagePortRecordProps = {
 
 
 export class MessagePortRecord extends ImmuRecord<MessagePortRecordProps>({
-	instanceIndex: 0,
+	instanceId: "0",
 	tag: "",
 	meta: {},
 	metaString: "",
@@ -22,11 +22,11 @@ export class MessagePortRecord extends ImmuRecord<MessagePortRecordProps>({
 	path: ""
 }) {
 
-	private static messagesArrayFromDescription(instanceIndex: PatcherInstanceRecord["index"], desc: OSCQueryRNBOInstanceMessageInfo, name: string): MessagePortRecord[] {
+	private static messagesArrayFromDescription(instanceId: PatcherInstanceRecord["id"], desc: OSCQueryRNBOInstanceMessageInfo, name: string): MessagePortRecord[] {
 		if (typeof desc.VALUE !== "undefined") {
 			return [
 				new MessagePortRecord({
-					instanceIndex,
+					instanceId,
 					tag: name,
 					path: (desc as OSCQueryRNBOInstanceMessageValue).FULL_PATH
 				}).setMeta((desc as OSCQueryRNBOInstanceMessageValue).CONTENTS?.meta?.VALUE || "")
@@ -36,15 +36,15 @@ export class MessagePortRecord extends ImmuRecord<MessagePortRecordProps>({
 		const result: MessagePortRecord[] = [];
 		for (const [subKey, subDesc] of Object.entries(desc.CONTENTS)) {
 			const subPrefix = name ? `${name}/${subKey}` : subKey;
-			result.push(...this.messagesArrayFromDescription(instanceIndex, subDesc, subPrefix));
+			result.push(...this.messagesArrayFromDescription(instanceId, subDesc, subPrefix));
 		}
 		return result;
 	}
 
-	public static fromDescription(instanceIndex: PatcherInstanceRecord["index"], messagesDesc?: OSCQueryRNBOInstanceMessages): MessagePortRecord[] {
+	public static fromDescription(instanceId: PatcherInstanceRecord["id"], messagesDesc?: OSCQueryRNBOInstanceMessages): MessagePortRecord[] {
 		const ports: MessagePortRecord[] = [];
 		for (const [name, desc] of Object.entries(messagesDesc?.CONTENTS || {})) {
-			ports.push(...this.messagesArrayFromDescription(instanceIndex, desc, name));
+			ports.push(...this.messagesArrayFromDescription(instanceId, desc, name));
 		}
 		return ports;
 	}

--- a/src/models/parameter.ts
+++ b/src/models/parameter.ts
@@ -7,7 +7,7 @@ export type ParameterRecordProps = {
 
 	enumVals: Array<string | number>;
 	index: number;
-	instanceIndex: number;
+	instanceId: string;
 	min: number;
 	max: number;
 	meta: ParameterMetaJsonMap;
@@ -25,7 +25,7 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 
 	enumVals: [],
 	index: 0,
-	instanceIndex: 0,
+	instanceId: "0",
 	min: 0,
 	max: 1,
 	meta: {},
@@ -41,7 +41,7 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 }) {
 
 	private static arrayFromDescription(
-		instanceIndex: number,
+		instanceId: string,
 		desc: OSCQueryRNBOInstanceParameterInfo,
 		name?: string
 	): ParameterRecord[] {
@@ -53,7 +53,7 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 			result.push((new ParameterRecord({
 				enumVals: paramInfo.RANGE?.[0]?.VALS || [],
 				index: paramInfo.CONTENTS?.index?.VALUE || 0,
-				instanceIndex,
+				instanceId,
 				min: paramInfo.RANGE?.[0]?.MIN,
 				max: paramInfo.RANGE?.[0]?.MAX,
 				name,
@@ -66,16 +66,16 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 			// Polyphonic params
 			for (const [subParamName, subDesc] of Object.entries(desc.CONTENTS) as Array<[string, OSCQueryRNBOInstanceParameterInfo]>) {
 				const subPrefix = name ? `${name}/${subParamName}` : subParamName;
-				result.push(...this.arrayFromDescription(instanceIndex, subDesc, subPrefix));
+				result.push(...this.arrayFromDescription(instanceId, subDesc, subPrefix));
 			}
 		}
 		return result;
 	}
 
-	public static fromDescription(instanceIndex: number, paramsDesc: OSCQueryRNBOInstance["CONTENTS"]["params"]): ParameterRecord[] {
+	public static fromDescription(instanceId: string, paramsDesc: OSCQueryRNBOInstance["CONTENTS"]["params"]): ParameterRecord[] {
 		const params: ParameterRecord[] = [];
 		for (const [name, desc] of Object.entries(paramsDesc.CONTENTS || {})) {
-			params.push(...ParameterRecord.arrayFromDescription(instanceIndex, desc, name));
+			params.push(...ParameterRecord.arrayFromDescription(instanceId, desc, name));
 		}
 		return params;
 	}
@@ -89,7 +89,7 @@ export class ParameterRecord extends ImmuRecord<ParameterRecordProps>({
 	}
 
 	public get setViewId(): string {
-		return instanceAndParamIndicesToSetViewEntry(this.instanceIndex, this.index);
+		return instanceAndParamIndicesToSetViewEntry(this.instanceId, this.index);
 	}
 
 	public getValueForNormalizedValue(nv: number): string | number {

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -27,7 +27,7 @@ export class GraphSetRecord extends ImmuRecord<GraphSetRecordProps>({
 }
 
 export type GraphSetViewParameterEntry = {
-	instanceIndex: PatcherInstanceRecord["index"];
+	instanceId: PatcherInstanceRecord["id"];
 	paramIndex: ParameterRecord["index"];
 }
 
@@ -50,12 +50,10 @@ export class GraphSetViewRecord extends ImmuRecord<GraphSetViewRecordProps>({
 	private static getParamListFromDesc(params: string[]): ImmuList<GraphSetViewParameterEntry> {
 		return ImmuList<GraphSetViewParameterEntry>().withMutations(list => {
 			for (const p of params) {
-				const [iIndex, pIndex] = p.split(":");
-
-				const instanceIndex = parseInt(iIndex, 10);
+				const [instanceId, pIndex] = p.split(":");
 				const paramIndex = parseInt(pIndex, 10);
-				if (!isNaN(instanceIndex) && !isNaN(paramIndex)) {
-					list.push({ instanceIndex, paramIndex });
+				if (!instanceId.length && !isNaN(paramIndex)) {
+					list.push({ instanceId, paramIndex });
 				}
 			}
 		});
@@ -81,10 +79,10 @@ export class GraphSetViewRecord extends ImmuRecord<GraphSetViewRecordProps>({
 		});
 	}
 
-	public get instanceIndices(): ImmuOrderedSet<GraphSetViewParameterEntry["instanceIndex"]> {
-		return ImmuOrderedSet<GraphSetViewParameterEntry["instanceIndex"]>()
+	public get instanceIds(): ImmuOrderedSet<GraphSetViewParameterEntry["instanceId"]> {
+		return ImmuOrderedSet<GraphSetViewParameterEntry["instanceId"]>()
 			.withMutations(set => {
-				this.params.forEach(p => set.add(p.instanceIndex));
+				this.params.forEach(p => set.add(p.instanceId));
 			});
 	}
 

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -52,7 +52,7 @@ export class GraphSetViewRecord extends ImmuRecord<GraphSetViewRecordProps>({
 			for (const p of params) {
 				const [instanceId, pIndex] = p.split(":");
 				const paramIndex = parseInt(pIndex, 10);
-				if (!instanceId.length && !isNaN(paramIndex)) {
+				if (instanceId.length && !isNaN(paramIndex)) {
 					list.push({ instanceId, paramIndex });
 				}
 			}

--- a/src/pages/instances/[id].tsx
+++ b/src/pages/instances/[id].tsx
@@ -31,8 +31,8 @@ export default function Instance() {
 	const [presetDrawerIsOpen, { close: closePresetDrawer, toggle: togglePresetDrawer }] = useDisclosure();
 	const [keyboardModalIsOpen, { close: closeKeyboardModal, toggle: toggleKeyboardModal }] = useDisclosure();
 
-	const { index, ...restQuery } = query;
-	const instanceId = Array.isArray(index) ? index.join("") : index || "0";
+	const { id, ...restQuery } = query;
+	const instanceId = Array.isArray(id) ? id.join("") : id || "0";
 
 	const dispatch = useAppDispatch();
 
@@ -67,7 +67,7 @@ export default function Instance() {
 	});
 
 	const onChangeInstance = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-		push({ pathname, query: { ...query, index: e.currentTarget.value } });
+		push({ pathname, query: { ...query, id: e.currentTarget.value } });
 	}, [push, pathname, query]);
 
 	const onUnloadInstance = useCallback((e: MouseEvent<HTMLButtonElement>) => {

--- a/src/pages/midimappings.tsx
+++ b/src/pages/midimappings.tsx
@@ -5,13 +5,14 @@ import { RootStateType } from "../lib/store";
 import classes from "../components/midi/midi.module.css";
 import { MIDIMappedParameterSortAttr, MIDIMetaMappingType, SortOrder } from "../lib/constants";
 import { useCallback, useEffect, useState } from "react";
-import { getPatcherInstanceParametersWithMIDIMapping, getPatcherInstancesByIndex } from "../selectors/patchers";
+import { getPatcherInstanceParametersWithMIDIMapping, getPatcherInstances } from "../selectors/patchers";
 import MIDIMappedParameterList from "../components/midi/mappedParameterList";
 import { ParameterRecord } from "../models/parameter";
 import { clearParameterMIDIMappingOnRemote, setParameterMIDIMappingOnRemoteFromDisplayValue } from "../actions/patchers";
 import { formatMIDIMappingToDisplay } from "../lib/util";
 
 const collator = new Intl.Collator("en-US", { numeric: true });
+
 const parameterComparators: Record<MIDIMappedParameterSortAttr, Record<SortOrder, (a: ParameterRecord, b: ParameterRecord) => number>> = {
 	[MIDIMappedParameterSortAttr.MIDISource]: {
 		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
@@ -25,15 +26,13 @@ const parameterComparators: Record<MIDIMappedParameterSortAttr, Record<SortOrder
 			return collator.compare(aDisplay, bDisplay) * -1;
 		}
 	},
-	[MIDIMappedParameterSortAttr.InstanceIndex]: {
+	[MIDIMappedParameterSortAttr.InstanceId]: {
 		[SortOrder.Asc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.instanceIndex < b.instanceIndex) return -1;
-			if (a.instanceIndex > b.instanceIndex) return 1;
+			if (a.instanceId !== b.instanceId) return collator.compare(a.instanceId, b.instanceId);
 			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
 		},
 		[SortOrder.Desc]: (a: ParameterRecord, b: ParameterRecord) => {
-			if (a.instanceIndex > b.instanceIndex) return -1;
-			if (a.instanceIndex < b.instanceIndex) return 1;
+			if (a.instanceId !== b.instanceId) return collator.compare(a.instanceId, b.instanceId) * -1;
 			return collator.compare(a.name.toLowerCase(), b.name.toLowerCase()) * -1;
 		}
 	},
@@ -62,7 +61,7 @@ const MIDIMappings = () => {
 		patcherInstances,
 		parameters
 	] = useAppSelector((state: RootStateType) => [
-		getPatcherInstancesByIndex(state),
+		getPatcherInstances(state),
 		getPatcherInstanceParametersWithMIDIMapping(state)
 	]);
 

--- a/src/reducers/graph.ts
+++ b/src/reducers/graph.ts
@@ -6,7 +6,7 @@ export interface GraphState {
 
 	connections: ImmuMap<GraphConnectionRecord["id"], GraphConnectionRecord>;
 	nodes: ImmuMap<GraphNodeRecord["id"], GraphNodeRecord>;
-	patcherNodeIdByIndex: ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord["id"]>;
+	patcherNodeIdByInstanceId: ImmuMap<GraphPatcherNodeRecord["instanceId"], GraphPatcherNodeRecord["id"]>;
 	portAliases: ImmuMap<GraphPortRecord["portName"], string[]>;
 
 }
@@ -15,7 +15,7 @@ export const graph = (state: GraphState = {
 
 	connections: ImmuMap<GraphConnectionRecord["id"], GraphConnectionRecord>(),
 	nodes: ImmuMap<GraphNodeRecord["id"], GraphNodeRecord>(),
-	patcherNodeIdByIndex: ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord["id"]>(),
+	patcherNodeIdByInstanceId: ImmuMap<GraphPatcherNodeRecord["instanceId"], GraphPatcherNodeRecord["id"]>(),
 	portAliases: ImmuMap<GraphPortRecord["portName"], string[]>()
 
 }, action: GraphAction): GraphState => {
@@ -27,7 +27,7 @@ export const graph = (state: GraphState = {
 			return {
 				...state,
 				nodes: state.nodes.delete(node.id),
-				patcherNodeIdByIndex: node.type === NodeType.Patcher ? state.patcherNodeIdByIndex.delete(node.index) : state.patcherNodeIdByIndex,
+				patcherNodeIdByInstanceId: node.type === NodeType.Patcher ? state.patcherNodeIdByInstanceId.delete(node.instanceId) : state.patcherNodeIdByInstanceId,
 				connections: state.connections
 					.filter(connection => connection.sourceNodeId !== node.id && connection.sinkNodeId !== node.id )
 			};
@@ -39,9 +39,9 @@ export const graph = (state: GraphState = {
 			return {
 				...state,
 				nodes: state.nodes.deleteAll(nodeIds),
-				patcherNodeIdByIndex: state.patcherNodeIdByIndex.deleteAll(
+				patcherNodeIdByInstanceId: state.patcherNodeIdByInstanceId.deleteAll(
 					(nodes.filter(n => n.type === NodeType.Patcher) as GraphPatcherNodeRecord[])
-						.map(n => n .index)
+						.map(n => n .instanceId)
 				),
 				connections: state.connections
 					.filter(connection => !nodeIds.includes(connection.sourceNodeId) && !nodeIds.includes(connection.sinkNodeId) )
@@ -53,7 +53,7 @@ export const graph = (state: GraphState = {
 			return {
 				...state,
 				nodes: state.nodes.set(node.id, node),
-				patcherNodeIdByIndex: node.type === NodeType.Patcher ? state.patcherNodeIdByIndex.set(node.index, node.id) : state.patcherNodeIdByIndex
+				patcherNodeIdByInstanceId: node.type === NodeType.Patcher ? state.patcherNodeIdByInstanceId.set(node.instanceId, node.id) : state.patcherNodeIdByInstanceId
 			};
 		}
 
@@ -66,10 +66,10 @@ export const graph = (state: GraphState = {
 						map.set(node.id, node);
 					}
 				}),
-				patcherNodeIdByIndex: state.patcherNodeIdByIndex.withMutations(map => {
+				patcherNodeIdByInstanceId: state.patcherNodeIdByInstanceId.withMutations(map => {
 					for (const node of nodes) {
 						if (node.type === NodeType.Patcher) {
-							map.set(node.index, node.id);
+							map.set(node.instanceId, node.id);
 						}
 					}
 				})

--- a/src/reducers/patchers.ts
+++ b/src/reducers/patchers.ts
@@ -62,22 +62,22 @@ export const patchers = (state: PatcherState = {
 			return {
 				...state,
 				instances: state.instances.delete(instance.id),
-				instanceParameters: state.instanceParameters.filter(param => param.instanceIndex !== instance.index),
-				instanceMessageInports: state.instanceMessageInports.filter(port => port.instanceIndex !== instance.index),
-				instanceMessageOutports: state.instanceMessageOutports.filter(port => port.instanceIndex !== instance.index)
+				instanceParameters: state.instanceParameters.filter(param => param.instanceId !== instance.id),
+				instanceMessageInports: state.instanceMessageInports.filter(port => port.instanceId !== instance.id),
+				instanceMessageOutports: state.instanceMessageOutports.filter(port => port.instanceId !== instance.id)
 			};
 		}
 
 		case PatcherActionType.DELETE_INSTANCES: {
 			const { instances } = action.payload;
-			const indexSet = new Set<number>(instances.map(i => i.index));
+			const idSet = new Set<string>(instances.map(i => i.id));
 
 			return {
 				...state,
 				instances: state.instances.deleteAll(instances.map(d => d.id)),
-				instanceParameters: state.instanceParameters.filter(param => !indexSet.has(param.instanceIndex)),
-				instanceMessageInports: state.instanceMessageInports.filter(port => !indexSet.has(port.instanceIndex)),
-				instanceMessageOutports: state.instanceMessageOutports.filter(port => !indexSet.has(port.instanceIndex))
+				instanceParameters: state.instanceParameters.filter(param => !idSet.has(param.instanceId)),
+				instanceMessageInports: state.instanceMessageInports.filter(port => !idSet.has(port.instanceId)),
+				instanceMessageOutports: state.instanceMessageOutports.filter(port => !idSet.has(port.instanceId))
 			};
 		}
 

--- a/src/selectors/graph.ts
+++ b/src/selectors/graph.ts
@@ -4,7 +4,7 @@ import { GraphConnectionRecord, GraphControlNodeRecord, GraphNodeRecord, GraphPa
 import { createSelector } from "reselect";
 
 export const getNodes = (state: RootStateType): ImmuMap<GraphNodeRecord["id"], GraphNodeRecord> => state.graph.nodes;
-export const getPatcherIdsByIndex = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord["id"]> => state.graph.patcherNodeIdByIndex;
+export const getPatcherNodeIdsByInstanceId = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["instanceId"], GraphPatcherNodeRecord["id"]> => state.graph.patcherNodeIdByInstanceId;
 
 export const getNode = createSelector(
 	[
@@ -24,31 +24,33 @@ export const getPatcherNodes = createSelector(
 	}
 );
 
-export const getPatcherNodeByIndex = createSelector(
+export const getPatcherNodeByInstanceId = createSelector(
 	[
 		getNodes,
-		getPatcherIdsByIndex,
-		(state: RootStateType, index: GraphPatcherNodeRecord["index"]): GraphPatcherNodeRecord["index"] => index
+		getPatcherNodeIdsByInstanceId,
+		(state: RootStateType, instanceId: GraphPatcherNodeRecord["instanceId"]): GraphPatcherNodeRecord["instanceId"] => instanceId
 	],
-	(nodes, idsByIndex, index): GraphPatcherNodeRecord | undefined => {
-		const id = idsByIndex.get(index);
+	(nodes, idsByInstanceId, instanceId): GraphPatcherNodeRecord | undefined => {
+		const id = idsByInstanceId.get(instanceId);
 		const node = id ? nodes.get(id) : undefined;
 		return node as GraphPatcherNodeRecord | undefined;
 	}
 );
 
-export const getFirstPatcherNodeIndex = createSelector(
-	[getPatcherIdsByIndex],
-	(idsByIndex): number | undefined => {
-		return idsByIndex.size === 0 ? undefined : idsByIndex.keySeq().sort().first();
+export const getFirstPatcherNodeId = createSelector(
+	[
+		getPatcherNodeIdsByInstanceId
+	],
+	(idsByInstanceId): string | undefined => {
+		return idsByInstanceId.size === 0 ? undefined : idsByInstanceId.keySeq().sort().first();
 	}
 );
 
-export const getPatcherNodesByIndex = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord> => {
-	return ImmuMap<GraphPatcherNodeRecord["index"], GraphPatcherNodeRecord>().withMutations(map => {
-		state.graph.patcherNodeIdByIndex.forEach((id, index) => {
-			const node = getNode(state, id);
-			if (node && node.type === NodeType.Patcher) map.set(index, node);
+export const getPatcherNodesByInstanceId = (state: RootStateType): ImmuMap<GraphPatcherNodeRecord["instanceId"], GraphPatcherNodeRecord> => {
+	return ImmuMap<GraphPatcherNodeRecord["instanceId"], GraphPatcherNodeRecord>().withMutations(map => {
+		state.graph.patcherNodeIdByInstanceId.forEach((nodeId, instanceId) => {
+			const node = getNode(state, nodeId);
+			if (node && node.type === NodeType.Patcher) map.set(instanceId, node);
 		});
 	});
 };

--- a/src/selectors/sets.ts
+++ b/src/selectors/sets.ts
@@ -19,14 +19,13 @@ export const getGraphSet = createSelector(
 	}
 );
 
-const collator = new Intl.Collator("en-US");
-
 export const getGraphSetsSortedByName = createSelector(
 	[
 		getGraphSets,
 		(state: RootStateType, order: SortOrder): SortOrder => order
 	],
 	(sets, order) => {
+		const collator = new Intl.Collator("en-US");
 		return sets.valueSeq().sort((left: GraphSetRecord, right: GraphSetRecord): number => {
 			return collator.compare(left.name, right.name) * (order === SortOrder.Asc ? 1 : -1);
 		});
@@ -54,6 +53,7 @@ export const getGraphSetPresetsSortedByName = createSelector(
 		(state: RootStateType, order: SortOrder): SortOrder => order
 	],
 	(presets, order) => {
+		const collator = new Intl.Collator("en-US");
 		return presets.valueSeq().sort((left: PresetRecord, right: PresetRecord): number => {
 			let result;
 			if (left.name === right.name) {
@@ -80,6 +80,7 @@ export const getGraphSetViewsBySortOrder = createSelector(
 		getGraphSetViews
 	],
 	(views): ImmuMap<GraphSetViewRecord["id"], GraphSetViewRecord> => {
+		const collator = new Intl.Collator("en-US");
 		return views.sort((va, vb) => {
 			if (va.sortOrder < vb.sortOrder) return -1;
 			if (va.sortOrder > vb.sortOrder) return 1;
@@ -93,8 +94,8 @@ export const getGraphSetView = createSelector(
 		getGraphSetViews,
 		(state: RootStateType, id: GraphSetViewRecord["id"]): string => id
 	],
-	(views, index): GraphSetViewRecord | undefined => {
-		return views.get(index);
+	(views, id): GraphSetViewRecord | undefined => {
+		return views.get(id);
 	}
 );
 


### PR DESCRIPTION
In order to reduce complexity we can just refer to the instance index as id. OSCQuery stores it as a string AFAICT anyway and there isn't really a need to track both, an id and a numeric index around. Ideally this will also help with further simplifying the graph data structures once we move towards port groups as part of #176 

Note that this is a PR on top of #192 