### PR TITLE
Trigger meta data /coordinates deletion for GraphPatcherNodes when unloading a node, instance or clearing a set

### DIFF
--- a/src/actions/meta.ts
+++ b/src/actions/meta.ts
@@ -1,0 +1,51 @@
+import throttle from "lodash.throttle";
+import { Map as ImmuMap } from "immutable";
+import { GraphNodeRecord } from "../models/graph";
+import { OSCQuerySetMeta } from "../lib/types";
+import { oscQueryBridge } from "../controller/oscqueryBridgeController";
+import { writePacket } from "osc";
+import { AppThunk } from "../lib/store";
+import { getNodes } from "../selectors/graph";
+
+export const serializeSetMeta = (nodes: GraphNodeRecord[]): string => {
+	const result: OSCQuerySetMeta = { nodes: {} };
+	for (const node of nodes) {
+		result.nodes[node.id] = { position: { x: node.x, y: node.y } };
+	}
+	return JSON.stringify(result);
+};
+
+export const deserializeSetMeta = (metaString: string): OSCQuerySetMeta => {
+	// I don't know why we're getting strings of length 1 but, they can't be valid JSON anyway
+	if (metaString && metaString.length > 1) {
+		try {
+			return JSON.parse(metaString) as OSCQuerySetMeta;
+		} catch (err) {
+			console.warn(`Failed to parse Set Meta when creating new node: ${err.message}`);
+		}
+	}
+	return { nodes: {} };
+};
+
+const doUpdateNodesMeta = throttle((nodes: ImmuMap<GraphNodeRecord["id"], GraphNodeRecord>) => {
+	try {
+		const value = serializeSetMeta(nodes.valueSeq().toArray());
+
+		const message = {
+			address: "/rnbo/inst/control/sets/meta",
+			args: [
+				{ type: "s", value }
+			]
+		};
+		oscQueryBridge.sendPacket(writePacket(message));
+	} catch (err) {
+		console.warn(`Failed to update Set Meta on remote: ${err.message}`);
+	}
+
+}, 150, { leading: true, trailing: true });
+
+export const updateSetMetaOnRemoteFromNodes = (nodes: ImmuMap<GraphNodeRecord["id"], GraphNodeRecord>): AppThunk =>
+	() => doUpdateNodesMeta(nodes);
+
+export const triggerSetMetaUpdateOnRemote = (): AppThunk =>
+	(dispatch, getState) => doUpdateNodesMeta(getNodes(getState()));

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -6,7 +6,7 @@ import { PresetRecord } from "../models/preset";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { updateSetMetaOnRemoteFromNodes } from "./meta";
-import { GraphNodeRecord, NodeType } from "../models/graph";
+import { NodeType } from "../models/graph";
 import { getNodes } from "../selectors/graph";
 
 export enum GraphSetActionType {

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -5,6 +5,9 @@ import { GraphSetRecord } from "../models/set";
 import { PresetRecord } from "../models/preset";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
+import { updateSetMetaOnRemoteFromNodes } from "./meta";
+import { GraphNodeRecord, NodeType } from "../models/graph";
+import { getNodes } from "../selectors/graph";
 
 export enum GraphSetActionType {
 	INIT_SETS = "INIT_SETS",
@@ -80,7 +83,7 @@ export const setGraphSetPresetLatest = (name: string): GraphSetAction => {
 };
 
 export const clearGraphSetOnRemote = (): AppThunk =>
-	(dispatch) => {
+	(dispatch, getState) => {
 		try {
 			const message = {
 				address: "/rnbo/inst/control/unload",
@@ -89,6 +92,8 @@ export const clearGraphSetOnRemote = (): AppThunk =>
 				]
 			};
 			oscQueryBridge.sendPacket(writePacket(message));
+			const nodes = getNodes(getState());
+			dispatch(updateSetMetaOnRemoteFromNodes(nodes.filter(n => n.type !== NodeType.Patcher)));
 		} catch (err) {
 			dispatch(showNotification({
 				level: NotificationLevel.error,


### PR DESCRIPTION
Close #140 