### PR TITLE
Handle renaming conflicts

### DIFF
--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -355,10 +355,13 @@ export const loadPresetOnRemoteInstance = (instance: PatcherInstanceRecord, pres
 		}
 	};
 
-export const savePresetToRemoteInstance = (instance: PatcherInstanceRecord, givenName: string): AppThunk =>
+export const savePresetToRemoteInstance = (instance: PatcherInstanceRecord, givenName: string, ensureUniqueName: boolean = true): AppThunk =>
 	(dispatch) => {
 		try {
-			const name = getUniqueName(givenName, instance.presets.valueSeq().map(p => p.name).toArray());
+			const name = ensureUniqueName
+				? getUniqueName(givenName, instance.presets.valueSeq().map(p => p.name).toArray())
+				: givenName;
+
 			const message = {
 				address: `${instance.path}/presets/save`,
 				args: [

--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -16,7 +16,7 @@ import { AppSetting } from "../models/settings";
 import { DataRefRecord } from "../models/dataref";
 import { DataFileRecord } from "../models/datafile";
 import { PatcherExportRecord } from "../models/patcher";
-import { cloneJSON, InvalidMIDIFormatError, parseMIDIMappingDisplayValue, UnknownMIDIFormatError } from "../lib/util";
+import { cloneJSON, getUniqueName, InvalidMIDIFormatError, parseMIDIMappingDisplayValue, UnknownMIDIFormatError } from "../lib/util";
 import { MIDIMetaMappingType } from "../lib/constants";
 
 export enum PatcherActionType {
@@ -355,9 +355,10 @@ export const loadPresetOnRemoteInstance = (instance: PatcherInstanceRecord, pres
 		}
 	};
 
-export const savePresetToRemoteInstance = (instance: PatcherInstanceRecord, name: string): AppThunk =>
+export const savePresetToRemoteInstance = (instance: PatcherInstanceRecord, givenName: string): AppThunk =>
 	(dispatch) => {
 		try {
+			const name = getUniqueName(givenName, instance.presets.valueSeq().map(p => p.name).toArray());
 			const message = {
 				address: `${instance.path}/presets/save`,
 				args: [

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -11,7 +11,7 @@ import { getNodes } from "../selectors/graph";
 import { ParameterRecord } from "../models/parameter";
 import { getPatcherInstance, getPatcherInstanceParamtersSortedByInstanceIdAndIndex } from "../selectors/patchers";
 import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewListState } from "../lib/types";
-import { getGraphSetView, getGraphSetViews } from "../selectors/sets";
+import { getGraphPresets, getGraphSets, getGraphSetView, getGraphSetViews } from "../selectors/sets";
 import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry } from "../lib/util";
 import { setInstanceWaitingForMidiMappingOnRemote } from "./patchers";
 
@@ -157,9 +157,13 @@ export const loadGraphSetOnRemote = (set: GraphSetRecord): AppThunk =>
 		}
 	};
 
-export const saveGraphSetOnRemote = (name: string): AppThunk =>
-	(dispatch) => {
+export const saveGraphSetOnRemote = (givenName: string): AppThunk =>
+	(dispatch, getState) => {
 		try {
+
+			const graphSets = getGraphSets(getState());
+			const name = getUniqueName(givenName, graphSets.valueSeq().map(s => s.name).toArray());
+
 			const message = {
 				address: "/rnbo/inst/control/sets/save",
 				args: [
@@ -247,9 +251,13 @@ export const loadSetPresetOnRemote = (preset: PresetRecord): AppThunk =>
 		}
 	};
 
-export const saveSetPresetToRemote = (name: string): AppThunk =>
-	(dispatch) => {
+export const saveSetPresetToRemote = (givenName: string): AppThunk =>
+	(dispatch, getState) => {
 		try {
+
+			const setPresets = getGraphPresets(getState());
+			const name = getUniqueName(givenName, setPresets.valueSeq().map(p => p.name).toArray());
+
 			const message = {
 				address: "/rnbo/inst/control/sets/presets/save",
 				args: [

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -157,12 +157,14 @@ export const loadGraphSetOnRemote = (set: GraphSetRecord): AppThunk =>
 		}
 	};
 
-export const saveGraphSetOnRemote = (givenName: string): AppThunk =>
+export const saveGraphSetOnRemote = (givenName: string, ensureUniqueName: boolean = true): AppThunk =>
 	(dispatch, getState) => {
 		try {
 
 			const graphSets = getGraphSets(getState());
-			const name = getUniqueName(givenName, graphSets.valueSeq().map(s => s.name).toArray());
+			const name = ensureUniqueName
+				? getUniqueName(givenName, graphSets.valueSeq().map(s => s.name).toArray())
+				: givenName;
 
 			const message = {
 				address: "/rnbo/inst/control/sets/save",

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -251,12 +251,14 @@ export const loadSetPresetOnRemote = (preset: PresetRecord): AppThunk =>
 		}
 	};
 
-export const saveSetPresetToRemote = (givenName: string): AppThunk =>
+export const saveSetPresetToRemote = (givenName: string, ensureUniqueName: boolean = true): AppThunk =>
 	(dispatch, getState) => {
 		try {
 
 			const setPresets = getGraphPresets(getState());
-			const name = getUniqueName(givenName, setPresets.valueSeq().map(p => p.name).toArray());
+			const name = ensureUniqueName
+				? getUniqueName(givenName, setPresets.valueSeq().map(p => p.name).toArray())
+				: givenName;
 
 			const message = {
 				address: "/rnbo/inst/control/sets/presets/save",

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -9,7 +9,7 @@ import { updateSetMetaOnRemoteFromNodes } from "./meta";
 import { NodeType } from "../models/graph";
 import { getNodes } from "../selectors/graph";
 import { ParameterRecord } from "../models/parameter";
-import { getPatcherInstance, getPatcherInstanceParamtersSortedByInstanceIdAndIndex } from "../selectors/patchers";
+import { getPatcherInstance, getPatcherInstanceParametersSortedByInstanceIdAndIndex } from "../selectors/patchers";
 import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewListState } from "../lib/types";
 import { getGraphPresets, getGraphSets, getGraphSetView, getGraphSetViews } from "../selectors/sets";
 import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry } from "../lib/util";
@@ -348,7 +348,7 @@ export const createSetViewOnRemote = (givenName: string): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
-			const params = getPatcherInstanceParamtersSortedByInstanceIdAndIndex(state);
+			const params = getPatcherInstanceParametersSortedByInstanceIdAndIndex(state);
 			const existingViews = getGraphSetViews(state);
 			const name = getUniqueName(givenName, existingViews.valueSeq().map(v => v.name).toArray());
 
@@ -542,7 +542,7 @@ export const removeParameterFromSetView = (setView: GraphSetViewRecord, param: P
 		}
 	};
 
-export const removeAllParamtersFromSetView = (setView: GraphSetViewRecord): AppThunk =>
+export const removeAllParametersFromSetView = (setView: GraphSetViewRecord): AppThunk =>
 	(dispatch) => {
 		try {
 			const message = {
@@ -582,12 +582,12 @@ export const addParameterToSetView = (setView: GraphSetViewRecord, param: Parame
 		}
 	};
 
-export const addAllParamtersToSetView = (setView: GraphSetViewRecord): AppThunk =>
+export const addAllParametersToSetView = (setView: GraphSetViewRecord): AppThunk =>
 	(dispatch, getState) => {
 		try {
 			const state = getState();
 			const params = setView.params.withMutations(list => {
-				getPatcherInstanceParamtersSortedByInstanceIdAndIndex(state)
+				getPatcherInstanceParametersSortedByInstanceIdAndIndex(state)
 					.forEach(param => {
 						if (!setView.paramIds.has(param.setViewId)) {
 							list.push({ instanceId: param.instanceId, paramIndex: param.index });

--- a/src/components/presets/index.tsx
+++ b/src/components/presets/index.tsx
@@ -46,6 +46,10 @@ const PresetDrawer: FunctionComponent<PresetDrawerProps> = memo(function Wrapped
 		});
 	}, [onDeletePreset]);
 
+	const validateUniquePresetName = useCallback((name: string): boolean => {
+		return !presets.find(p => p.name === name);
+	}, [presets]);
+
 	return (
 		<Drawer
 			opened={ open }
@@ -58,7 +62,17 @@ const PresetDrawer: FunctionComponent<PresetDrawerProps> = memo(function Wrapped
 			<DrawerSectionTitle>Saved Presets</DrawerSectionTitle>
 			<Stack gap="sm">
 				{
-					presets.map(preset => <PresetItem key={ preset.id } preset={ preset } onLoad={ onLoadPreset } onDelete={ onTriggerDeletePreset } onRename = { onRenamePreset } onSetInitial = { onSetInitialPreset }/> )
+					presets.map(preset => (
+						<PresetItem
+							key={ preset.id }
+							preset={ preset }
+							onLoad={ onLoadPreset }
+							onDelete={ onTriggerDeletePreset }
+							onRename = { onRenamePreset }
+							onSetInitial = { onSetInitialPreset }
+							validateUniqueName={ validateUniquePresetName }
+						/>
+					))
 				}
 			</Stack>
 		</Drawer>

--- a/src/components/presets/index.tsx
+++ b/src/components/presets/index.tsx
@@ -14,7 +14,8 @@ export type PresetDrawerProps = {
 	onClose: () => any;
 	onDeletePreset: (preset: PresetRecord) => any;
 	onLoadPreset: (preset: PresetRecord) => any;
-	onSavePreset: (name: string) => any;
+	onCreatePreset: (name: string) => any;
+	onSavePreset: (preset: PresetRecord) => any;
 	onRenamePreset: (preset: PresetRecord, name: string) => any;
 	onSetInitialPreset?: (set: PresetRecord) => any;
 	presets: Seq.Indexed<PresetRecord>;
@@ -23,6 +24,7 @@ export type PresetDrawerProps = {
 const PresetDrawer: FunctionComponent<PresetDrawerProps> = memo(function WrappedPresetDrawer({
 	open,
 	onClose,
+	onCreatePreset,
 	onDeletePreset,
 	onLoadPreset,
 	onSavePreset,
@@ -57,7 +59,7 @@ const PresetDrawer: FunctionComponent<PresetDrawerProps> = memo(function Wrapped
 			position="right"
 			title={ <Group gap="xs"><IconElement path={ mdiCamera }/> Presets</Group> }
 		>
-			<SavePresetForm onSave={ onSavePreset } />
+			<SavePresetForm onSave={ onCreatePreset } />
 			<Divider mt="lg" />
 			<DrawerSectionTitle>Saved Presets</DrawerSectionTitle>
 			<Stack gap="sm">
@@ -68,7 +70,8 @@ const PresetDrawer: FunctionComponent<PresetDrawerProps> = memo(function Wrapped
 							preset={ preset }
 							onLoad={ onLoadPreset }
 							onDelete={ onTriggerDeletePreset }
-							onRename = { onRenamePreset }
+							onRename={ onRenamePreset }
+							onSave={ onSavePreset }
 							onSetInitial = { onSetInitialPreset }
 							validateUniqueName={ validateUniquePresetName }
 						/>

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -12,6 +12,7 @@ export type PresetItemProps = {
 	onLoad: (set: PresetRecord) => any;
 	onRename: (set: PresetRecord, name: string) => any;
 	onSetInitial?: (set: PresetRecord) => any;
+	validateUniqueName: (name: string) => boolean;
 };
 
 export const PresetItem: FunctionComponent<PresetItemProps> = memo(function WrappedPresetItem({
@@ -19,7 +20,8 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	onDelete,
 	onLoad,
 	onRename,
-	onSetInitial
+	onSetInitial,
+	validateUniqueName
 }: PresetItemProps) {
 
 	const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -45,12 +47,16 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	const onRenamePreset = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		inputRef.current?.focus();
-		if (!name?.length) {
+		if (preset.name === name) {
+			setIsEditing(false);
+		} else if (!name?.length) {
 			setError("Please provide a valid preset name");
+		} else if (!validateUniqueName(name)) {
+			setError(`A preset with the name "${name}" already exists`);
 		} else {
 			onRename(preset, name);
 		}
-	}, [name, onRename, preset, setError, inputRef]);
+	}, [name, onRename, preset, setError, inputRef, setIsEditing, validateUniqueName]);
 
 	const onDeletePreset = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
 		onDelete(preset);

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -53,14 +53,15 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	const onRenamePreset = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		inputRef.current?.focus();
-		if (preset.name === name) {
+		const trimmedName = name.trim();
+		if (preset.name === trimmedName) {
 			setIsEditing(false);
-		} else if (!name?.length) {
+		} else if (!trimmedName?.length) {
 			setError("Please provide a valid preset name");
-		} else if (!validateUniqueName(name)) {
-			setError(`A preset with the name "${name}" already exists`);
+		} else if (!validateUniqueName(trimmedName)) {
+			setError(`A preset with the name "${trimmedName}" already exists`);
 		} else {
-			onRename(preset, name);
+			onRename(preset, trimmedName);
 		}
 	}, [name, onRename, preset, setError, inputRef, setIsEditing, validateUniqueName]);
 

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -73,6 +73,15 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	}, [toggleEditing]);
 
 	useEffect(() => {
+		if (isEditing && inputRef.current) {
+			inputRef.current.focus();
+		}
+		if (!isEditing) {
+			setError(undefined);
+		}
+	}, [isEditing, inputRef, setError]);
+
+	useEffect(() => {
 		setName(preset.name);
 		setIsEditing(false);
 	}, [preset, setName, setIsEditing]);

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -4,14 +4,15 @@ import classes from "./presets.module.css";
 import { PresetRecord } from "../../models/preset";
 import { keyEventIsValidForName, replaceInvalidNameChars } from "../../lib/util";
 import { IconElement } from "../elements/icon";
-import { mdiCheck, mdiClose, mdiDotsVertical, mdiHistory, mdiPencil, mdiStar, mdiTrashCan } from "@mdi/js";
+import { mdiCheck, mdiClose, mdiContentSave, mdiDotsVertical, mdiHistory, mdiPencil, mdiStar, mdiTrashCan } from "@mdi/js";
 
 export type PresetItemProps = {
 	preset: PresetRecord;
-	onDelete: (set: PresetRecord) => any;
-	onLoad: (set: PresetRecord) => any;
-	onRename: (set: PresetRecord, name: string) => any;
-	onSetInitial?: (set: PresetRecord) => any;
+	onDelete: (preset: PresetRecord) => any;
+	onLoad: (preset: PresetRecord) => any;
+	onRename: (preset: PresetRecord, name: string) => any;
+	onSave: (preset: PresetRecord) => any;
+	onSetInitial?: (preset: PresetRecord) => any;
 	validateUniqueName: (name: string) => boolean;
 };
 
@@ -20,6 +21,7 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	onDelete,
 	onLoad,
 	onRename,
+	onSave,
 	onSetInitial,
 	validateUniqueName
 }: PresetItemProps) {
@@ -39,6 +41,10 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 	const onSetInitialPreset = useCallback(() => {
 		onSetInitial(preset);
 	}, [preset, onSetInitial]);
+
+	const onSavePreset = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
+		onSave(preset);
+	}, [onSave, preset]);
 
 	const onLoadPreset = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
 		onLoad(preset);
@@ -154,8 +160,10 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 				</Menu.Target>
 				<Menu.Dropdown>
 					<Menu.Label>Preset Actions</Menu.Label>
+					<Menu.Item leftSection={ <IconElement path={ mdiContentSave } /> } onClick={ onSavePreset } >Overwrite</Menu.Item>
 					<Menu.Item leftSection={ <IconElement path={ mdiPencil } /> } onClick={ toggleEditing } >Rename</Menu.Item>
 					{ onSetInitial && <Menu.Item leftSection={ <IconElement path={ mdiStar } /> } onClick={ onSetInitialPreset } >Load on Startup</Menu.Item> }
+					<Menu.Divider />
 					<Menu.Item color="red" leftSection={ <IconElement path={ mdiTrashCan } /> } onClick={ onDeletePreset } >Delete</Menu.Item>
 				</Menu.Dropdown>
 			</Menu>

--- a/src/components/presets/item.tsx
+++ b/src/components/presets/item.tsx
@@ -44,12 +44,13 @@ export const PresetItem: FunctionComponent<PresetItemProps> = memo(function Wrap
 
 	const onRenamePreset = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		inputRef.current?.focus();
 		if (!name?.length) {
 			setError("Please provide a valid preset name");
 		} else {
 			onRename(preset, name);
 		}
-	}, [name, onRename, preset, setError]);
+	}, [name, onRename, preset, setError, inputRef]);
 
 	const onDeletePreset = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
 		onDelete(preset);

--- a/src/components/presets/save.tsx
+++ b/src/components/presets/save.tsx
@@ -20,11 +20,12 @@ export const SavePresetForm: FunctionComponent<SavePresetFormProps> = memo(funct
 
 	const onSavePreset = (e: FormEvent<HTMLFormElement>): void => {
 		e.preventDefault();
-		if (!name?.length) {
+		const trimmedName = name.trim();
+		if (!trimmedName?.length) {
 			setError("Please provide a valid preset name");
 		} else {
 			setError(undefined);
-			onSave(name);
+			onSave(trimmedName);
 			setName("");
 		}
 	};

--- a/src/components/setViews/create.tsx
+++ b/src/components/setViews/create.tsx
@@ -18,9 +18,10 @@ export const CreateSetViewForm: FC<CreateSetViewFormProps> = memo(function Wrapp
 		if (error && e.target.value?.length) setError(undefined);
 	};
 
-	const onSavePreset = (e: FormEvent<HTMLFormElement>): void => {
+	const onSaveSetView = (e: FormEvent<HTMLFormElement>): void => {
 		e.preventDefault();
-		if (!name?.length) {
+		const trimmedName = name.trim();
+		if (!trimmedName?.length) {
 			setError("Please provide a valid SetView name");
 		} else {
 			setError(undefined);
@@ -36,7 +37,7 @@ export const CreateSetViewForm: FC<CreateSetViewFormProps> = memo(function Wrapp
 	}, []);
 
 	return (
-		<form onSubmit={ onSavePreset } >
+		<form onSubmit={ onSaveSetView } >
 			<Group gap="xs" align="flex-end">
 				<TextInput
 					label="Create SetView"

--- a/src/components/setViews/drawer.tsx
+++ b/src/components/setViews/drawer.tsx
@@ -49,6 +49,10 @@ const SetViewDrawer: FC<CreateSetViewModalProps> = ({
 		});
 	}, [onDeleteSetView]);
 
+	const validateUniqueSetViewName = useCallback((name: string): boolean => {
+		return !setViews.find(v => v.name === name);
+	}, [setViews]);
+
 	return (
 
 		<Drawer
@@ -70,6 +74,7 @@ const SetViewDrawer: FC<CreateSetViewModalProps> = ({
 							onDelete={ onTriggerDeleteSetView }
 							onRename={ onRenameSetView }
 							onLoad={ onLoadSetView }
+							validateUniqueName={ validateUniqueSetViewName }
 						/>
 					))
 				}

--- a/src/components/setViews/item.tsx
+++ b/src/components/setViews/item.tsx
@@ -43,14 +43,15 @@ export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function Wrapped
 	const onRenameSetView = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		inputRef.current?.focus();
-		if (setView.name === name) {
+		const trimmedName = name.trim();
+		if (setView.name === trimmedName) {
 			setIsEditing(false);
-		} else if (!name?.length) {
+		} else if (!trimmedName?.length) {
 			setError("Please provide a valid SetView name");
-		} else if (!validateUniqueName(name)) {
-			setError(`A SetView with the name "${name}" already exists`);
+		} else if (!validateUniqueName(trimmedName)) {
+			setError(`A SetView with the name "${trimmedName}" already exists`);
 		} else {
-			onRename(setView, name);
+			onRename(setView, trimmedName);
 		}
 	}, [name, onRename, setView, setError, setIsEditing, validateUniqueName]);
 

--- a/src/components/setViews/item.tsx
+++ b/src/components/setViews/item.tsx
@@ -12,6 +12,7 @@ export type GraphSetViewItemProps = {
 	onLoad: (set: GraphSetViewRecord) => any;
 	onRename: (set: GraphSetViewRecord, name: string) => any;
 	setView: GraphSetViewRecord;
+	validateUniqueName: (name: string) => boolean;
 };
 
 export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function WrappedGraphSetViewItem({
@@ -19,7 +20,8 @@ export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function Wrapped
 	onDelete,
 	onLoad,
 	onRename,
-	setView
+	setView,
+	validateUniqueName
 }: GraphSetViewItemProps) {
 
 	const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -40,12 +42,17 @@ export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function Wrapped
 
 	const onRenameSetView = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		if (!name?.length) {
+		inputRef.current?.focus();
+		if (setView.name === name) {
+			setIsEditing(false);
+		} else if (!name?.length) {
 			setError("Please provide a valid SetView name");
+		} else if (!validateUniqueName(name)) {
+			setError(`A SetView with the name "${name}" already exists`);
 		} else {
 			onRename(setView, name);
 		}
-	}, [name, onRename, setView, setError]);
+	}, [name, onRename, setView, setError, setIsEditing]);
 
 	const onDeleteSetView = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
 		onDelete(setView);
@@ -72,6 +79,15 @@ export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function Wrapped
 		setName(setView.name);
 		setIsEditing(false);
 	}, [setView, setName, setIsEditing]);
+
+	useEffect(() => {
+		if (isEditing && inputRef.current) {
+			inputRef.current.focus();
+		}
+		if (!isEditing) {
+			setError(undefined);
+		}
+	}, [isEditing, inputRef, setError]);
 
 	return isEditing ? (
 		<form onSubmit={ onRenameSetView } >

--- a/src/components/setViews/item.tsx
+++ b/src/components/setViews/item.tsx
@@ -52,7 +52,7 @@ export const GraphSetViewItem: FC<GraphSetViewItemProps> = memo(function Wrapped
 		} else {
 			onRename(setView, name);
 		}
-	}, [name, onRename, setView, setError, setIsEditing]);
+	}, [name, onRename, setView, setError, setIsEditing, validateUniqueName]);
 
 	const onDeleteSetView = useCallback((_e: MouseEvent<HTMLButtonElement>) => {
 		onDelete(setView);

--- a/src/components/setViews/paramModal.tsx
+++ b/src/components/setViews/paramModal.tsx
@@ -11,7 +11,7 @@ import { PatcherInstanceRecord } from "../../models/instance";
 import { OrderedSet as ImmuOrderedSet, Seq } from "immutable";
 import { ParameterRecord } from "../../models/parameter";
 import { ResponsiveButton } from "../elements/responsiveButton";
-import { addAllParamtersToSetView, addParameterToSetView, removeAllParamtersFromSetView, removeParameterFromSetView } from "../../actions/sets";
+import { addAllParametersToSetView, addParameterToSetView, removeAllParametersFromSetView, removeParameterFromSetView } from "../../actions/sets";
 import classes from "./setviews.module.css";
 import { modals } from "@mantine/modals";
 
@@ -112,7 +112,7 @@ export const SetViewParameterModal: FC<SetViewParameterModalProps> = memo(functi
 				</Text>
 			),
 			labels: { confirm: "Add", cancel: "Cancel" },
-			onConfirm: () => dispatch(addAllParamtersToSetView(setView))
+			onConfirm: () => dispatch(addAllParametersToSetView(setView))
 		});
 
 	}, [dispatch, setView]);
@@ -128,7 +128,7 @@ export const SetViewParameterModal: FC<SetViewParameterModalProps> = memo(functi
 			),
 			labels: { confirm: "Remove", cancel: "Cancel" },
 			confirmProps: { color: "red" },
-			onConfirm: () => dispatch(removeAllParamtersFromSetView(setView))
+			onConfirm: () => dispatch(removeAllParametersFromSetView(setView))
 		});
 	}, [dispatch, setView]);
 

--- a/src/components/sets/index.tsx
+++ b/src/components/sets/index.tsx
@@ -13,11 +13,11 @@ import { mdiEraser, mdiGroup } from "@mdi/js";
 export type SetsDrawerProps = {
 	onClose: () => any;
 	onClearSet: () => any;
+	onCreateSet: (name: string) => any;
 	onDeleteSet: (set: GraphSetRecord) => any;
 	onLoadSet: (set: GraphSetRecord) => any;
 	onRenameSet: (set: GraphSetRecord, name: string) => any;
-	onSaveSet: (name: string) => any;
-	onSaveSetAs: (set: GraphSetRecord) => any;
+	onSaveSet: (set: GraphSetRecord) => any;
 	open: boolean;
 	sets: Seq.Indexed<GraphSetRecord>;
 }
@@ -28,11 +28,11 @@ const SetsDrawer: FunctionComponent<SetsDrawerProps> = memo(function WrappedSets
 	sets,
 
 	onClearSet,
+	onCreateSet,
 	onDeleteSet,
 	onLoadSet,
 	onRenameSet,
-	onSaveSet,
-	onSaveSetAs
+	onSaveSet
 
 }) {
 
@@ -86,7 +86,7 @@ const SetsDrawer: FunctionComponent<SetsDrawerProps> = memo(function WrappedSets
 					</Drawer.Header>
 					<Drawer.Body style={{ flex: 1 }} >
 						<Flex direction="column" style={{ height: "100%" }} gap="lg" >
-							<SaveGraphSetForm onSave={ onSaveSet } />
+							<SaveGraphSetForm onSave={ onCreateSet } />
 							<Divider />
 							<Flex className={ classes.setListWrapper } direction="column">
 								<DrawerSectionTitle>Saved Graph Sets</DrawerSectionTitle>
@@ -99,7 +99,7 @@ const SetsDrawer: FunctionComponent<SetsDrawerProps> = memo(function WrappedSets
 												onRename={ onRenameSet }
 												onLoad={ onLoadSet }
 												onDelete={ onTriggerDeleteSet }
-												onSave={ onSaveSetAs }
+												onSave={ onSaveSet }
 												validateUniqueName={ validateUniqueSetName }
 											/>
 										))

--- a/src/components/sets/index.tsx
+++ b/src/components/sets/index.tsx
@@ -66,6 +66,10 @@ const SetsDrawer: FunctionComponent<SetsDrawerProps> = memo(function WrappedSets
 		});
 	}, [onClearSet]);
 
+	const validateUniqueSetName = useCallback((name: string): boolean => {
+		return !sets.find(s => s.name === name);
+	}, [sets]);
+
 	return (
 		<Drawer.Root opened={ open } onClose={ onClose } position="right">
 			<Drawer.Overlay />
@@ -88,7 +92,17 @@ const SetsDrawer: FunctionComponent<SetsDrawerProps> = memo(function WrappedSets
 								<DrawerSectionTitle>Saved Graph Sets</DrawerSectionTitle>
 								<Stack gap="sm" >
 									{
-										sets.map(set => <GraphSetItem key={ set.id } set={ set } onRename={ onRenameSet } onLoad={ onLoadSet } onDelete={ onTriggerDeleteSet } onSave={ onSaveSetAs }/> )
+										sets.map(set => (
+											<GraphSetItem
+												key={ set.id }
+												set={ set }
+												onRename={ onRenameSet }
+												onLoad={ onLoadSet }
+												onDelete={ onTriggerDeleteSet }
+												onSave={ onSaveSetAs }
+												validateUniqueName={ validateUniqueSetName }
+											/>
+										))
 									}
 								</Stack>
 							</Flex>

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -12,6 +12,7 @@ export type GraphSetItemProps = {
 	onLoad: (set: GraphSetRecord) => any;
 	onRename: (set: GraphSetRecord, name: string) => any;
 	onSave: (set: GraphSetRecord) => any;
+	validateUniqueName: (name: string) => boolean;
 };
 
 export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function WrappedGraphSet({
@@ -19,7 +20,8 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 	onDelete,
 	onLoad,
 	onRename,
-	onSave
+	onSave,
+	validateUniqueName
 }: GraphSetItemProps) {
 
 	const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -37,12 +39,16 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 	const onRenameSet = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		inputRef.current?.focus();
-		if (!name?.length) {
+		if (set.name === name) {
+			setIsEditing(false);
+		} else if (!name?.length) {
 			setError("Please provide a valid set name");
+		} else if (!validateUniqueName(name)) {
+			setError((`A set with the name "${name} already exists"`));
 		} else {
 			onRename(set, name);
 		}
-	}, [name, onRename, set, setError, inputRef]);
+	}, [name, onRename, set, setError, inputRef, setIsEditing]);
 
 	const onLoadSet = useCallback((e: MouseEvent<HTMLButtonElement>) => {
 		onLoad(set);
@@ -61,7 +67,7 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 		if (error && e.target.value?.length) setError(undefined);
 	}, [setName, error, setError]);
 
-	const onKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+	const onKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>): void => {
 		if (e.key === "Escape") {
 			e.preventDefault();
 			e.stopPropagation();

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -48,7 +48,7 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 		} else {
 			onRename(set, name);
 		}
-	}, [name, onRename, set, setError, inputRef, setIsEditing]);
+	}, [name, onRename, set, setError, inputRef, setIsEditing, validateUniqueName]);
 
 	const onLoadSet = useCallback((e: MouseEvent<HTMLButtonElement>) => {
 		onLoad(set);

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -39,14 +39,15 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 	const onRenameSet = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		inputRef.current?.focus();
-		if (set.name === name) {
+		const trimmedName = name.trim();
+		if (set.name === trimmedName) {
 			setIsEditing(false);
-		} else if (!name?.length) {
+		} else if (!trimmedName?.length) {
 			setError("Please provide a valid set name");
-		} else if (!validateUniqueName(name)) {
-			setError((`A set with the name "${name} already exists"`));
+		} else if (!validateUniqueName(trimmedName)) {
+			setError((`A set with the name "${trimmedName} already exists"`));
 		} else {
-			onRename(set, name);
+			onRename(set, trimmedName);
 		}
 	}, [name, onRename, set, setError, inputRef, setIsEditing, validateUniqueName]);
 

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -36,12 +36,13 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 
 	const onRenameSet = useCallback((e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		inputRef.current?.focus();
 		if (!name?.length) {
 			setError("Please provide a valid set name");
 		} else {
 			onRename(set, name);
 		}
-	}, [name, onRename, set, setError]);
+	}, [name, onRename, set, setError, inputRef]);
 
 	const onLoadSet = useCallback((e: MouseEvent<HTMLButtonElement>) => {
 		onLoad(set);

--- a/src/components/sets/item.tsx
+++ b/src/components/sets/item.tsx
@@ -141,8 +141,9 @@ export const GraphSetItem: FunctionComponent<GraphSetItemProps> = memo(function 
 				</Menu.Target>
 				<Menu.Dropdown>
 					<Menu.Label>Graph Set Actions</Menu.Label>
-					<Menu.Item leftSection={ <IconElement path={ mdiContentSave } /> } onClick={ onSaveSet } >{ set.latest ? "Save Changes" : "Overwrite" }</Menu.Item>
+					<Menu.Item leftSection={ <IconElement path={ mdiContentSave } /> } onClick={ onSaveSet } >Overwrite</Menu.Item>
 					<Menu.Item leftSection={ <IconElement path={ mdiPencil } /> } onClick={ toggleEditing } >Rename</Menu.Item>
+					<Menu.Divider />
 					<Menu.Item color="red" leftSection={ <IconElement path={ mdiTrashCan } /> } onClick={ onDeleteSet } >Delete</Menu.Item>
 				</Menu.Dropdown>
 			</Menu>

--- a/src/components/sets/save.tsx
+++ b/src/components/sets/save.tsx
@@ -19,11 +19,12 @@ export const SaveGraphSetForm: FunctionComponent<SaveGraphSetFormProps> = memo(f
 
 	const onSaveSet = (e: FormEvent<HTMLFormElement>): void => {
 		e.preventDefault();
-		if (!name?.length) {
+		const trimmedName = name.trim();
+		if (!trimmedName?.length) {
 			setError("Please provide a valid set name");
 		} else {
 			setError(undefined);
-			onSave(name);
+			onSave(trimmedName);
 			setName("");
 		}
 	};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -169,8 +169,25 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		dispatch(loadSetPresetOnRemote(preset));
 	}, [dispatch]);
 
-	const onSavePreset = useCallback((name: string) => {
+	const onCreatePreset = useCallback((name: string) => {
 		dispatch(saveSetPresetToRemote(name));
+	}, [dispatch]);
+
+	const onSavePreset = useCallback((preset: PresetRecord) => {
+		modals.openConfirmModal({
+			title: "Overwrite Preset",
+			centered: true,
+			children: (
+				<Text size="sm">
+					Are you sure you want to overwrite the preset named { `"${preset.name}"` } with the current values?
+				</Text>
+			),
+			labels: { confirm: "Overwrite", cancel: "Cancel" },
+			confirmProps: { color: "red" },
+			onConfirm: () => {
+				dispatch(saveSetPresetToRemote(preset.name, false));
+			}
+		});
 	}, [dispatch]);
 
 	const onDeletePreset = useCallback((preset: PresetRecord) => {
@@ -261,8 +278,9 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 				onClose={ closePresetDrawer }
 				onDeletePreset={ onDeletePreset }
 				onLoadPreset={ onLoadPreset }
-				onSavePreset={ onSavePreset }
+				onCreatePreset={ onCreatePreset }
 				onRenamePreset={ onRenamePreset }
+				onSavePreset={ onSavePreset }
 				presets={ graphPresets }
 			/>
 		</>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -144,24 +144,20 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 	}, [dispatch]);
 
 	const onSaveSet = useCallback((set: GraphSetRecord) => {
-		if (set.latest) {
-			dispatch(saveGraphSetOnRemote(set.name));
-		} else {
-			modals.openConfirmModal({
-				title: "Overwrite Set",
-				centered: true,
-				children: (
-					<Text size="sm">
-						Are you sure you want to overwrite the set named { `"${set.name}"` }?
-					</Text>
-				),
-				labels: { confirm: "Overwrite", cancel: "Cancel" },
-				confirmProps: { color: "red" },
-				onConfirm: () => {
-					dispatch(saveGraphSetOnRemote(set.name));
-				}
-			});
-		}
+		modals.openConfirmModal({
+			title: "Overwrite Set",
+			centered: true,
+			children: (
+				<Text size="sm">
+					Are you sure you want to overwrite the set named { `"${set.name}"` }?
+				</Text>
+			),
+			labels: { confirm: "Overwrite", cancel: "Cancel" },
+			confirmProps: { color: "red" },
+			onConfirm: () => {
+				dispatch(saveGraphSetOnRemote(set.name, false));
+			}
+		});
 	}, [dispatch]);
 
 	// Presets

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -139,11 +139,11 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		dispatch(renameGraphSetOnRemote(set, name));
 	}, [dispatch]);
 
-	const onSaveSet = useCallback((name: string) => {
+	const onCreateSet = useCallback((name: string) => {
 		dispatch(saveGraphSetOnRemote(name));
 	}, [dispatch]);
 
-	const onSaveSetAs = useCallback((set: GraphSetRecord) => {
+	const onSaveSet = useCallback((set: GraphSetRecord) => {
 		if (set.latest) {
 			dispatch(saveGraphSetOnRemote(set.name));
 		} else {
@@ -268,8 +268,8 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 				onDeleteSet={ onDeleteSet }
 				onLoadSet={ onLoadSet }
 				onRenameSet={ onRenameSet }
+				onCreateSet={ onCreateSet }
 				onSaveSet={ onSaveSet }
-				onSaveSetAs={ onSaveSetAs }
 				open={ setDrawerIsOpen }
 				sets={ graphSets }
 			/>

--- a/src/pages/instances/[id].tsx
+++ b/src/pages/instances/[id].tsx
@@ -92,8 +92,25 @@ export default function Instance() {
 		dispatch(loadPresetOnRemoteInstance(currentInstance, preset));
 	}, [dispatch, currentInstance]);
 
-	const onSavePreset = useCallback((name: string) => {
+	const onCreatePreset = useCallback((name: string) => {
 		dispatch(savePresetToRemoteInstance(currentInstance, name));
+	}, [dispatch, currentInstance]);
+
+	const onSavePreset = useCallback((preset: PresetRecord) => {
+		modals.openConfirmModal({
+			title: "Overwrite Preset",
+			centered: true,
+			children: (
+				<Text size="sm">
+					Are you sure you want to overwrite the preset named { `"${preset.name}"` } with the current values?
+				</Text>
+			),
+			labels: { confirm: "Overwrite", cancel: "Cancel" },
+			confirmProps: { color: "red" },
+			onConfirm: () => {
+				dispatch(savePresetToRemoteInstance(currentInstance, preset.name, false));
+			}
+		});
 	}, [dispatch, currentInstance]);
 
 	const onDeletePreset = useCallback((preset: PresetRecord) => {
@@ -178,8 +195,9 @@ export default function Instance() {
 				onClose={ closePresetDrawer }
 				onDeletePreset={ onDeletePreset }
 				onLoadPreset={ onLoadPreset }
-				onSavePreset={ onSavePreset }
+				onCreatePreset={ onCreatePreset }
 				onRenamePreset={ onRenamePreset }
+				onSavePreset={ onSavePreset }
 				onSetInitialPreset={ onSetInitialPreset }
 				presets={ currentInstance.presets.valueSeq() }
 			/>

--- a/src/pages/setviews.tsx
+++ b/src/pages/setviews.tsx
@@ -19,7 +19,7 @@ import { IconElement } from "../components/elements/icon";
 export default function SetViews() {
 
 	const [setViewDrawerOpen, { open: openSetViewDrawer, close: closeSetViewDrawer }] = useDisclosure(false);
-	const [addParametersViewOpen, { open: openAddParametersView, close: closeAddParamtersView }] = useDisclosure(false);
+	const [addParametersViewOpen, { open: openAddParametersView, close: closeAddParametersView }] = useDisclosure(false);
 	const dispatch = useAppDispatch();
 
 	const [
@@ -169,7 +169,7 @@ export default function SetViews() {
 			{
 				currentSetView && addParametersViewOpen ? (
 					<SetViewParameterModal
-						onClose={ closeAddParamtersView }
+						onClose={ closeAddParametersView }
 						setView={ currentSetView }
 					/>
 				) : null

--- a/src/selectors/patchers.ts
+++ b/src/selectors/patchers.ts
@@ -48,7 +48,7 @@ export const getPatcherInstance = createSelector(
 
 export const getPatcherInstanceParameters = (state: RootStateType): ImmuMap<ParameterRecord["id"], ParameterRecord> => state.patchers.instanceParameters;
 
-export const getPatcherInstanceParamtersSortedByInstanceIdAndIndex = createSelector(
+export const getPatcherInstanceParametersSortedByInstanceIdAndIndex = createSelector(
 	[
 		getPatcherInstanceParameters
 	],


### PR DESCRIPTION
This PR prevents overwriting existing presets (both on instance as well as set level), sets and setviews by ensuring name conflicts are marked as an error.

Note I made this PR on top of the views work to get uniqueness validation for SetViews in there already as well as resusing the `getUniqueName` util that was already in place here.

closes #147 

