### PR TITLE
Logic for handling new, unsaved Graphs

### DIFF
--- a/src/actions/patchers.ts
+++ b/src/actions/patchers.ts
@@ -16,7 +16,7 @@ import { AppSetting } from "../models/settings";
 import { DataRefRecord } from "../models/dataref";
 import { DataFileRecord } from "../models/datafile";
 import { PatcherExportRecord } from "../models/patcher";
-import { cloneJSON, getUniqueName, InvalidMIDIFormatError, parseMIDIMappingDisplayValue, UnknownMIDIFormatError } from "../lib/util";
+import { cloneJSON, getUniqueName, InvalidMIDIFormatError, parseMIDIMappingDisplayValue, UnknownMIDIFormatError, validatePresetName } from "../lib/util";
 import { MIDIMetaMappingType } from "../lib/constants";
 import { DialogResult, showConfirmDialog, showTextInputDialog } from "../lib/dialogs";
 
@@ -459,11 +459,7 @@ export const createPresetOnRemoteInstance = (instance: PatcherInstanceRecord): A
 				actions: {
 					confirm: { label: "Create Preset" }
 				},
-				validate: (v: string) => {
-					const value = v.trim();
-					if (!value?.length) return "Please provide a valid, non empty name.";
-					return true;
-				}
+				validate: validatePresetName
 			});
 
 			if (dialogResult === DialogResult.Cancel) {

--- a/src/actions/sets.ts
+++ b/src/actions/sets.ts
@@ -9,7 +9,7 @@ import { ParameterRecord } from "../models/parameter";
 import { getPatcherInstance, getPatcherInstanceParametersSortedByInstanceIdAndIndex } from "../selectors/patchers";
 import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewState } from "../lib/types";
 import { getCurrentGraphSet, getCurrentGraphSetIsDirty, getGraphPresets, getGraphSets, getGraphSetView, getGraphSetViews } from "../selectors/sets";
-import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry, sleep } from "../lib/util";
+import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry, sleep, validatePresetName, validateSetViewName } from "../lib/util";
 import { setInstanceWaitingForMidiMappingOnRemote } from "./patchers";
 import { DialogResult, showConfirmDialog, showTextInputDialog } from "../lib/dialogs";
 
@@ -396,11 +396,7 @@ export const createSetPresetOnRemote = (): AppThunk =>
 				actions: {
 					confirm: { label: "Create Preset" }
 				},
-				validate: (v: string) => {
-					const value = v.trim();
-					if (!value?.length) return "Please provide a valid, non empty name.";
-					return true;
-				}
+				validate: validatePresetName
 			});
 
 			if (dialogResult === DialogResult.Cancel) {
@@ -534,11 +530,7 @@ export const createSetViewOnRemote = (): AppThunk =>
 				actions: {
 					confirm: { label: "Create Parameter View" }
 				},
-				validate: (v: string) => {
-					const value = v.trim();
-					if (!value?.length) return "Please provide a valid, non empty name.";
-					return true;
-				}
+				validate: validateSetViewName
 			});
 
 			if (dialogResult === DialogResult.Cancel) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -125,3 +125,5 @@ export enum RNBOJackPortPropertyKey {
 	PrettyName = "http://jackaudio.org/metadata/pretty-name",
 	Terminal = "terminal"
 }
+
+export const UnsavedSetName = "(untitled)";

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,6 @@
 import { KeyboardEvent, memo } from "react";
 import { AnyJson, JsonMap, MIDIChannelPressureMetaMapping, MIDIControlChangeMetaMapping, MIDIKeypressMetaMapping, MIDIMetaMapping, MIDINoteMetaMapping, MIDIPitchBendMetaMapping, MIDIProgramChangeMetaMapping, OSCQueryStringValueRange, OSCQueryValueRange } from "./types";
-import { MIDIMetaMappingType, nodePortHeight, nodePortSpacing } from "./constants";
+import { MIDIMetaMappingType, nodePortHeight, nodePortSpacing, UnsavedSetName } from "./constants";
 
 export const genericMemo: <P>(component: P) => P = memo;
 
@@ -216,3 +216,22 @@ export const parseMIDIMappingDisplayValue = (value: string): { type: MIDIMetaMap
 export const calculateNodeContentHeight = (sinkCount: number, sourceCount: number): number => {
 	return (sinkCount > sourceCount ? sinkCount : sourceCount) * (nodePortHeight + nodePortSpacing);
 };
+
+export const validateGraphSetName = (v: string): true | string => {
+	const value = v.trim();
+	if (!value?.length) return "Please provide a valid, non empty name.";
+	if (value === UnsavedSetName) return `"${UnsavedSetName}" is a reserved name, please use a non-reserved name.`;
+	return true;
+};
+
+export const validatePresetName = (v: string): true | string => {
+	const value = v.trim();
+	if (!value?.length) return "Please provide a valid, non empty name.";
+	return true;
+};
+
+export const validateSetViewName = (v: string): true | string => {
+	const value = v.trim();
+	if (!value?.length) return "Please provide a valid, non empty name.";
+	return true;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 	triggerEditorFitView
 } from "../actions/editor";
 import SetsDrawer from "../components/sets";
-import { destroySetPresetOnRemote, loadSetPresetOnRemote, renameSetPresetOnRemote, loadNewEmptyGraphSetOnRemote, destroyGraphSetOnRemote, loadGraphSetOnRemote, renameGraphSetOnRemote, saveGraphSetOnRemote, overwriteGraphSetOnRemote, overwriteSetPresetOnRemote, createSetPresetOnRemote } from "../actions/sets";
+import { destroySetPresetOnRemote, loadSetPresetOnRemote, renameSetPresetOnRemote, loadNewEmptyGraphSetOnRemote, destroyGraphSetOnRemote, loadGraphSetOnRemote, renameGraphSetOnRemote, saveGraphSetOnRemote, overwriteGraphSetOnRemote, overwriteSetPresetOnRemote, createSetPresetOnRemote, saveCurrentGraphSetOnRemote } from "../actions/sets";
 import { PresetRecord } from "../models/preset";
 import { getCurrentGraphSet, getCurrentGraphSetIsDirty, getGraphSetPresetsSortedByName, getGraphSetsSortedByName } from "../selectors/sets";
 import { useDisclosure } from "@mantine/hooks";
@@ -136,7 +136,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 
 	const onSaveCurrentSet = useCallback(() => {
 		if (!currentGraphSet) return;
-		dispatch(saveGraphSetOnRemote(currentGraphSet.name, false));
+		dispatch(saveCurrentGraphSetOnRemote());
 	}, [dispatch, currentGraphSet]);
 
 	const onOverwriteSet = useCallback((set: GraphSetRecord) => {


### PR DESCRIPTION
This adds handling for new, so far unsaved graphs based on the assumption that they are called / labeled as `(untitled)` by the runner.

Marking this as draft for now for further discussion

see #212 