### PR TITLE
clean up nodes without ports when receiving port props

### DIFF
--- a/src/actions/graph.ts
+++ b/src/actions/graph.ts
@@ -2,8 +2,8 @@ import { writePacket } from "osc";
 import { oscQueryBridge } from "../controller/oscqueryBridgeController";
 import { ActionBase, AppThunk, RootStateType } from "../lib/store";
 import { OSCQueryRNBOJackConnections, OSCQueryRNBOJackPortInfo, OSCQuerySetMeta } from "../lib/types";
-import { ConnectionType, GraphConnectionRecord, GraphNodeRecord, GraphPortRecord, NodePositionRecord, NodeType, PortDirection } from "../models/graph";
-import { getConnectionsForSourcePort, getNode, getNodes, getConnections, getPorts, getPort, getPortsForTypeAndDirection, getPatcherNodeByInstanceId, getNodePositions, getNodePosition, getEditorNodesAndPorts, getPortsForNodeId } from "../selectors/graph";
+import { GraphConnectionRecord, GraphNodeRecord, GraphPortRecord, NodePositionRecord, NodeType } from "../models/graph";
+import { getConnectionsForSourcePort, getNode, getNodes, getConnections, getPorts, getPort, getNodePositions, getNodePosition, getEditorNodesAndPorts } from "../selectors/graph";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { PatcherExportRecord } from "../models/patcher";
@@ -362,16 +362,13 @@ export const updateSetMetaFromRemote = (setMeta: OSCQuerySetMeta): AppThunk =>
 	};
 
 const makePorts = (
-	portIds: string[],
-	type: ConnectionType,
-	direction: PortDirection,
 	propertyMap: OSCQueryRNBOJackPortInfo["CONTENTS"]["properties"]["CONTENTS"],
 	aliasesMap:  OSCQueryRNBOJackPortInfo["CONTENTS"]["aliases"]["CONTENTS"]
 ): GraphPortRecord[] => {
 	const result: GraphPortRecord[] = [];
 
-	for (const id of portIds) {
-		let port = GraphPortRecord.fromDescription(id, type, direction, propertyMap[id]?.VALUE || "{}");
+	for (const [id, properties] of Object.entries(propertyMap)) {
+		let port = GraphPortRecord.fromDescription(id, properties.VALUE || "{}");
 		if (aliasesMap[port.id]) port = port.setAliases(aliasesMap[port.id].VALUE);
 
 		result.push(port);
@@ -387,13 +384,8 @@ export const initPorts = (jackPortsInfo: OSCQueryRNBOJackPortInfo): AppThunk =>
 
 		const portProperties = jackPortsInfo.CONTENTS?.properties?.CONTENTS || {};
 		const portAliases = jackPortsInfo.CONTENTS.aliases?.CONTENTS || {};
-		const ports: Array<GraphPortRecord> = [
-			...makePorts(jackPortsInfo.CONTENTS.audio.CONTENTS?.sources?.VALUE || [], ConnectionType.Audio, PortDirection.Source, portProperties, portAliases),
-			...makePorts(jackPortsInfo.CONTENTS.midi.CONTENTS?.sources?.VALUE || [], ConnectionType.MIDI, PortDirection.Source, portProperties, portAliases),
-			...makePorts(jackPortsInfo.CONTENTS.audio.CONTENTS?.sinks?.VALUE || [], ConnectionType.Audio, PortDirection.Sink, portProperties, portAliases),
-			...makePorts(jackPortsInfo.CONTENTS.midi.CONTENTS?.sinks?.VALUE || [], ConnectionType.MIDI, PortDirection.Sink, portProperties, portAliases)
-		];
 
+		const ports: Array<GraphPortRecord> = makePorts(portProperties, portAliases);
 		const nodes: Map<GraphNodeRecord["id"], GraphNodeRecord> = new Map<GraphNodeRecord["id"], GraphNodeRecord>();
 
 		for (const port of ports) {
@@ -464,60 +456,12 @@ export const initConnections = (connectionsInfo: OSCQueryRNBOJackConnections): A
 		dispatch(setConnections(connectionRecords));
 	};
 
-
-// Update Port I/O Info
-export const updatePortIOInfo = (type: ConnectionType, direction: PortDirection, ids: string[]): AppThunk =>
-	(dispatch, getState) => {
-
-		const state = getState();
-		const currentPorts = getPortsForTypeAndDirection(state, type, direction);
-
-		const portsToDelete = currentPorts.filter(p => !ids.includes(p.id));
-		if (portsToDelete.size > 0) {
-			dispatch(deletePorts(portsToDelete.valueSeq().toArray()));
-		}
-
-		const updatedPorts: GraphPortRecord[] = [];
-		for (const portId of ids) {
-			let port: GraphPortRecord;
-			if (currentPorts.has(portId)) {
-				port = currentPorts.get(portId)
-					.setDirection(direction)
-					.setType(type);
-			} else {
-				port = GraphPortRecord.fromDescription(portId, type, direction, "{}");
-			}
-			updatedPorts.push(port);
-		}
-
-		const newNodes = updatedPorts
-			.filter(p => !getNode(state, p.nodeId))
-			.map(p => GraphNodeRecord.fromDescription(p.nodeId, NodeType.System));
-
-		dispatch(setPorts(updatedPorts));
-
-		if (newNodes.length) {
-			dispatch(setNodes(newNodes));
-			dispatch(setNodePositions(
-				newNodes.map(n => NodePositionRecord
-					.fromDescription(
-						n.id,
-						patcherInstanceCoordinatesStore.xWithMargin,
-						patcherInstanceCoordinatesStore.yWithMargin
-					)
-				)
-			));
-		}
-	};
-
-export const addPort = (id: GraphPortRecord["id"]): AppThunk =>
+export const addPort = (id: GraphPortRecord["id"], properties: string = "{}"): AppThunk =>
 	(dispatch, getState) => {
 
 		const port = getPort(getState(), id);
 		if (port) return;
-		dispatch(setPort(
-			GraphPortRecord.fromDescription(id, ConnectionType.Audio, PortDirection.Sink, "{}")
-		));
+		dispatch(setPort(GraphPortRecord.fromDescription(id, properties)));
 	};
 
 export const setPortAliases = (id: GraphPortRecord["id"], aliases: string []): AppThunk =>
@@ -540,50 +484,24 @@ export const setPortProperties = (id: GraphPortRecord["id"], properties: string)
 	(dispatch, getState) => {
 
 		const state = getState();
-		const currentPort = getPort(state, id);
-		if (!currentPort) return;
+		const port = getPort(state, id)?.setProperties(properties) || GraphPortRecord.fromDescription(id, properties);
 
 		// Create Port
-		const updatedPort = currentPort.setProperties(properties);
-		dispatch(setPort(updatedPort));
+		dispatch(setPort(port));
 
-		if (updatedPort.instanceId !== undefined) {
-			// Check if we need to update the node if of a patcher instance id
-			// this is necessary as we don't really have anything else that maps between
-			// /rnbo/inst/<id> to the <nodeid>:<port_name> when an instance is added
-
-			// Rename patcher node from inst id to node id
-			let patcherNode = getPatcherNodeByInstanceId(state, updatedPort.instanceId);
-			if (patcherNode) {
-				patcherNode = patcherNode.set("id", updatedPort.nodeId);
-				dispatch(setNode(patcherNode));
+		if (!getNodePosition(state, port.nodeId)) {
+			let pos: NodePositionRecord;
+			if (port.isPatcherInstancePort) {
+				pos = NodePositionRecord.fromDescription(port.nodeId, patcherInstanceCoordinatesStore.xWithMargin, patcherInstanceCoordinatesStore.yWithMargin);
+			} else {
+				const coords = getGraphEditorInstance(getState())?.project({ x: 0, y: 0 }) || { x: 0, y: 0 };
+				pos = getNodePosition(state, port.nodeId) || NodePositionRecord.fromDescription(port.nodeId, coords.x, coords.y);
 			}
-
-			// Rename position node from inst id to node id
-			const position = getNodePosition(state, updatedPort.instanceId);
-			if (position) {
-				dispatch(setNodePosition(position.set("id", updatedPort.nodeId)));
-			} else if (!getNodePosition(state, updatedPort.nodeId)) {
-				// Create position
-				dispatch(setNodePosition(NodePositionRecord.fromDescription(updatedPort.nodeId, patcherInstanceCoordinatesStore.xWithMargin, patcherInstanceCoordinatesStore.yWithMargin)));
-			}
-
-		} else if (!getNode(state, updatedPort.nodeId)) {
-			// Need to create a system node and position for it
-			const node = getNode(state, currentPort.nodeId) || GraphNodeRecord.fromDescription(updatedPort.nodeId, NodeType.System);
-			const coords = getGraphEditorInstance(getState())?.project({ x: 0, y: 0 }) || { x: 0, y: 0 };
-			const pos = getNodePosition(state, currentPort.nodeId) || NodePositionRecord.fromDescription(updatedPort.nodeId, coords.x, coords.y);
-
-			dispatch(setNode(node));
 			dispatch(setNodePosition(pos));
 		}
 
-		if (updatedPort.instanceId === undefined && currentPort.nodeId !== updatedPort.nodeId && getPortsForNodeId(state, currentPort.nodeId).size === 1) {
-			const node = getNode(state, currentPort.nodeId);
-			if (node) dispatch(deleteNode(node));
-			const pos = getNodePosition(state, currentPort.nodeId);
-			if (pos) dispatch(deleteNodePosition(pos));
-		}
+		const node = getNode(state, port.nodeId) || GraphNodeRecord.fromDescription(port.nodeId, port.isPatcherInstancePort ? NodeType.Patcher : NodeType.System);
+		dispatch(setNode(node.set("type", port.isPatcherInstancePort ? NodeType.Patcher : NodeType.System)));
 	};
 
 // Trigger Updates on remote OSCQuery Runner

--- a/src/controller/oscqueryBridgeController.ts
+++ b/src/controller/oscqueryBridgeController.ts
@@ -5,7 +5,7 @@ import { AppDispatch, store } from "../lib/store";
 import { ReconnectingWebsocket } from "../lib/reconnectingWs";
 import { AppStatus, RunnerCmdMethod } from "../lib/constants";
 import { OSCQueryRNBOState, OSCQueryRNBOInstance, OSCQueryRNBOPatchersState, OSCValue, OSCQueryRNBOInstancesMetaState, OSCQuerySetMeta } from "../lib/types";
-import { deletePortAliases, initConnections, initPorts, setPortAliases, updateSetMetaFromRemote, updateSourcePortConnections, updatePortIOInfo, deletePortById, setPortProperties, addPort } from "../actions/graph";
+import { deletePortAliases, initConnections, initPorts, setPortAliases, updateSetMetaFromRemote, updateSourcePortConnections, deletePortById, setPortProperties, addPort } from "../actions/graph";
 import { addInstance, deleteInstanceById, initInstances, initPatchers, updateInstanceParameterDisplayName } from "../actions/patchers";
 import { initRunnerConfig, updateRunnerConfig } from "../actions/settings";
 import { initSets, setCurrentGraphSet, initSetPresets, setGraphSetPresetLatest, initSetViews, updateSetViewName, updateSetViewParameterList, deleteSetView, addSetView, updateSetViewOrder, setCurrentGraphSetDirtyState } from "../actions/sets";
@@ -22,7 +22,6 @@ import {
 	removeInstanceMessageInportByPath,
 	removeInstanceMessageOutportByPath
 } from "../actions/patchers";
-import { ConnectionType, PortDirection } from "../models/graph";
 import { showNotification } from "../actions/notifications";
 import { NotificationLevel } from "../models/notification";
 import { initTransport, updateTransportStatus } from "../actions/transport";
@@ -40,7 +39,6 @@ enum OSCQueryCommand {
 	ATTRIBUTES_CHANGED = "ATTRIBUTES_CHANGED"
 }
 
-const portIOPathMatcher = /^\/rnbo\/jack\/info\/ports\/(?<type>audio|midi)\/(?<direction>sources|sinks)$/;
 const portPropertiesPathMatcher = /^\/rnbo\/jack\/info\/ports\/properties\/(?<port>.+)$/;
 const portAliasPathMatcher = /^\/rnbo\/jack\/info\/ports\/aliases\/(?<port>.+)$/;
 const patchersPathMatcher = /^\/rnbo\/patchers/;
@@ -612,14 +610,6 @@ export class OSCQueryBridgeControllerPrivate {
 				}
 			}
 			return;
-		}
-
-		// Handle Graph Port I/O Updates
-		const portIOMatch = packet.address.match(portIOPathMatcher);
-		if (portIOMatch) {
-			const type: ConnectionType = portIOMatch.groups.type === "midi" ? ConnectionType.MIDI : ConnectionType.Audio;
-			const direction: PortDirection = portIOMatch.groups.direction === "sinks" ? PortDirection.Sink : PortDirection.Source;
-			return void dispatch(updatePortIOInfo(type, direction, packet.args as unknown as string[]));
 		}
 
 		// Handle Port Alias setting

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -123,7 +123,9 @@ export enum RNBOJackPortPropertyKey {
 	Physical = "physical",
 	PortGroup = "http://jackaudio.org/metadata/port-group",
 	PrettyName = "http://jackaudio.org/metadata/pretty-name",
-	Terminal = "terminal"
+	Source = "source",
+	Terminal = "terminal",
+	Type = "type"
 }
 
 export const UnsavedSetName = "(untitled)";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,4 @@
+import { ConnectionType } from "../models/graph";
 import { KnownPortGroup, RNBOJackPortPropertyKey } from "./constants";
 
 // See https://github.com/Microsoft/TypeScript/issues/1897
@@ -174,7 +175,9 @@ export type RNBOJackPortProperties = {
 	[RNBOJackPortPropertyKey.Physical]?: true;
 	[RNBOJackPortPropertyKey.PortGroup]?: KnownPortGroup | string;
 	[RNBOJackPortPropertyKey.PrettyName]?: string;
+	[RNBOJackPortPropertyKey.Source]: boolean;
 	[RNBOJackPortPropertyKey.Terminal]?: true;
+	[RNBOJackPortPropertyKey.Type]: ConnectionType;
 }
 
 export type OSCQueryRNBOJackPortInfo = OSCQueryBaseNode & {


### PR DESCRIPTION
Added a stopgap fix for #104 here that should address the issue.

However, I wonder if we should harden the port management further by simplifying it. The current code basically creates ports and nodes from `/rnbo/jack/info/ports/audio|midi` and then later on shuffles the nodes around once the properties are received in order to assign / maintain the correct group.

Not sure what your appetite for this is now @x37v. The frontend could do a lookup for the port id in order to determine `type` and `direction` but I wonder if adding the port `type` and `direction` to the entries in `/rnbo/jack/info/ports/properties` directly would make this much easier? Ideally managing / syncing the ports from the audio and midi entries becomes obsolete and we could solely manage port / node state based on the properties. What do you think?