### PR TITLE
Fix Edge Delete prior to Instance Delete confirmation

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -154,22 +154,6 @@ export const removeEditorNodeById = (id: GraphNode["id"], updateSetMeta = true):
 		}
 	};
 
-export const removeEditorNodesById = (ids: GraphNodeRecord["id"][]): AppThunk =>
-	(dispatch, getState) => {
-		for (const id of ids) {
-			dispatch(removeEditorNodeById(id, false));
-		}
-		// Only at the end update the meta to ensure all coord data has been removed
-		updateSetMetaOnRemoteFromNodes(getNodes(getState()).deleteAll(ids).valueSeq().toArray());
-	};
-
-export const removeEditorConnectionsById = (ids: GraphConnectionRecord["id"][]): AppThunk =>
-	(dispatch) => {
-		for (const id of ids) {
-			dispatch(removeEditorConnectionById(id));
-		}
-	};
-
 export const changeNodePosition = (id: GraphNode["id"], x: number, y: number): AppThunk =>
 	(dispatch, getState) => {
 		const state = getState();
@@ -215,7 +199,9 @@ export const applyEditorNodeChanges = (changes: NodeChange[]): AppThunk =>
 					break;
 				}
 
-				case "remove": // handled separetely via dedicated action
+				case "remove":
+					dispatch(removeEditorNodeById(change.id));
+					break;
 				case "add":
 				case "reset":
 				case "dimensions":
@@ -234,7 +220,9 @@ export const applyEditorEdgeChanges = (changes: EdgeChange[]): AppThunk =>
 					break;
 				}
 
-				case "remove": // handled separetely via dedicated action
+				case "remove":
+					dispatch(removeEditorConnectionById(change.id));
+					break;
 				case "add":
 				case "reset":
 				default:

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -1,7 +1,7 @@
 import { Connection, EdgeChange, NodeChange, ReactFlowInstance } from "reactflow";
 import { ActionBase, AppThunk } from "../lib/store";
 import { getConnection, getConnectionByPorts, getConnections, getEditorNodesAndPorts, getNode, getNodePosition, getNodes, getPort, getPorts } from "../selectors/graph";
-import { GraphConnectionRecord, GraphNode, GraphNodeRecord, NodeType } from "../models/graph";
+import { GraphConnectionRecord, GraphNode, NodeType } from "../models/graph";
 import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { writePacket } from "osc";

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -146,7 +146,7 @@ export const removeEditorNodeById = (id: GraphNode["id"], updateSetMeta = true):
 
 		} catch (err) {
 			dispatch(showNotification({
-				title: "Failed to node",
+				title: "Failed to delete node",
 				level: NotificationLevel.error,
 				message: err.message
 			}));

--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -139,9 +139,7 @@ export const removeEditorNodeById = (id: GraphNode["id"], updateSetMeta = true):
 				throw new Error(`Node with id ${id} does not exist.`);
 			}
 
-			if (node.type === NodeType.System) {
-				throw new Error(`System nodes cannot be removed (id: ${id}).`);
-			}
+			if (node.type === NodeType.System) return;
 
 			dispatch(unloadPatcherNodeOnRemote(node.instanceId));
 			if (updateSetMeta) updateSetMetaOnRemoteFromNodes(getNodes(state).delete(node.id).valueSeq().toArray());

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -24,9 +24,7 @@ export type GraphEditorProps = {
 	ports: RootStateType["graph"]["ports"];
 
 	onConnect: (connection: Connection) => any;
-	onNodesDelete: (nodes: Pick<Edge, "id">[]) => void;
 	onNodesChange: (changes: NodeChange[]) => void;
-	onEdgesDelete: (edges: Pick<Edge, "id">[]) => void;
 	onEdgesChange: (changes: EdgeChange[]) => void;
 
 	zoom: number;
@@ -53,9 +51,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 
 	onConnect,
 	onNodesChange,
-	onNodesDelete,
 	onEdgesChange,
-	onEdgesDelete,
 
 	nodeInfo,
 	ports,
@@ -82,8 +78,8 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 	}, [ports]);
 
 	const triggerDeleteEdge = useCallback((id: GraphConnectionRecord["id"]) => {
-		onEdgesDelete([{ id }]);
-	}, [onEdgesDelete]);
+		onEdgesChange([{ id, type: "remove" }]);
+	}, [onEdgesChange]);
 
 	const onNodeDoubleClick = useCallback((e: React.MouseEvent, node: Node<NodeDataProps>) => {
 		if (node.type !== NodeType.Patcher) return;
@@ -134,9 +130,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 				isValidConnection={ validateConnection }
 				edges={ flowEdges }
 				nodes={ flowNodes }
-				onEdgesDelete={ onEdgesDelete }
 				onEdgesChange={ onEdgesChange }
-				onNodesDelete={ onNodesDelete }
 				onNodesChange={ onNodesChange }
 				onNodeDoubleClick={ onNodeDoubleClick }
 				onConnect={ onConnect }

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -17,6 +17,7 @@ import { IconElement } from "../elements/icon";
 import { mdiFitToScreen, mdiLock, mdiLockOpen, mdiMinus, mdiPlus, mdiSitemap } from "@mdi/js";
 import { maxEditorZoom, minEditorZoom } from "../../lib/constants";
 import { EditorNodeDesc } from "../../selectors/graph";
+import { getHotkeyHandler } from "@mantine/hooks";
 
 export type GraphEditorProps = {
 	connections: RootStateType["graph"]["connections"];
@@ -81,6 +82,14 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 		onEdgesChange([{ id, type: "remove" }]);
 	}, [onEdgesChange]);
 
+	const handleHotKeyDelete = useCallback(() => {
+		const edgeChanges: EdgeChange[] = connections.valueSeq().filter(c => c.selected).toArray().map(c => ({ id: c.id, type: "remove" }));
+		if (edgeChanges.length) onEdgesChange(edgeChanges);
+
+		const nodeChanges: NodeChange[] = nodeInfo.valueSeq().filter(info => info.node.selected).toArray().map(info => ({ id: info.node.id, type: "remove" }));
+		if (nodeChanges.length) onNodesChange(nodeChanges);
+	}, [connections, nodeInfo, onEdgesChange, onNodesChange]);
+
 	const onNodeDoubleClick = useCallback((e: React.MouseEvent, node: Node<NodeDataProps>) => {
 		if (node.type !== NodeType.Patcher) return;
 		push({ pathname: "/instances/[id]", query: { ...query, id: node.data.node.instanceId }});
@@ -128,6 +137,7 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 		<div className={ classes.editor } data-color-scheme={ colorScheme } >
 			<ReactFlow
 				isValidConnection={ validateConnection }
+				deleteKeyCode={[]}
 				edges={ flowEdges }
 				nodes={ flowNodes }
 				onEdgesChange={ onEdgesChange }
@@ -146,6 +156,9 @@ const GraphEditor: FunctionComponent<GraphEditorProps> = memo(function WrappedFl
 				nodesConnectable={ !locked }
 				edgesFocusable={ !locked }
 				elementsSelectable={ !locked }
+				onKeyDown={ getHotkeyHandler([
+					["backspace", handleHotKeyDelete]
+				]) }
 			/>
 			<div className={ classes.controls } >
 				<ActionIcon.Group orientation="vertical">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { getPatchersSortedByName } from "../selectors/patchers";
 import { getConnections, getEditorNodesAndPorts, getPorts } from "../selectors/graph";
 import GraphEditor from "../components/editor";
 import PresetDrawer from "../components/presets";
-import { Connection, Edge, EdgeChange, Node, NodeChange, ReactFlowInstance } from "reactflow";
+import { Connection, EdgeChange, NodeChange, ReactFlowInstance } from "reactflow";
 import { loadPatcherNodeOnRemote } from "../actions/graph";
 import {
 	applyEditorEdgeChanges, applyEditorNodeChanges, createEditorConnection,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,6 @@ import {
 	editorZoomIn,
 	editorZoomOut,
 	generateEditorLayout,
-	removeEditorConnectionsById, removeEditorNodesById,
 	toggleEditorLockedState,
 	triggerEditorFitView
 } from "../actions/editor";
@@ -102,17 +101,9 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 		dispatch(applyEditorNodeChanges(changes));
 	}, [dispatch]);
 
-	const onNodesDelete = useCallback((nodes: Pick<Node, "id">[]) => {
-		dispatch(removeEditorNodesById(nodes.map(n => n.id)));
-	}, [dispatch]);
-
 	// Edges
 	const onEdgesChange = useCallback((changes: EdgeChange[]) => {
 		dispatch(applyEditorEdgeChanges(changes));
-	}, [dispatch]);
-
-	const onEdgesDelete = useCallback((edges: Pick<Edge, "id">[]) => {
-		dispatch(removeEditorConnectionsById(edges.map(e => e.id)));
 	}, [dispatch]);
 
 	// Sets
@@ -212,9 +203,7 @@ const Index: FunctionComponent<Record<string, never>> = () => {
 
 					onConnect={ onConnectNodes }
 					onNodesChange={ onNodesChange }
-					onNodesDelete={ onNodesDelete }
 					onEdgesChange={ onEdgesChange }
-					onEdgesDelete={ onEdgesDelete }
 
 					onInit={ onEditorInit }
 					onAutoLayout={ onEditorAutoLayout }


### PR DESCRIPTION
Noticed a bug where we would propagate through the request from ReactFlow to delete edges when one hits backspace, albeit the user not having confirmed the instance deletion in the popup modal.

Got around this by using a custom, global hot key handler for the editor and solely operating based on EdgeChanges and NodeChanges in conjunction with the selection state.