### PR TITLE
Fix Port Property Updates

### DIFF
--- a/src/actions/recording.ts
+++ b/src/actions/recording.ts
@@ -42,7 +42,7 @@ export const initStreamRecording = (state?: OSCQueryRNBOJackRecord): IInitStream
 		type: StreamRecordingActionType.INIT,
 		payload: {
 			active: state?.CONTENTS?.active?.TYPE === OSCQueryValueType.True,
-			capturedTime: state?.CONTENTS.captured?.VALUE || 0
+			capturedTime: state?.CONTENTS?.captured?.VALUE || 0
 		}
 	};
 };


### PR DESCRIPTION
OK turns out the jack info state syncing "swallowed" the port property synchronization leading to nodes being unmovable and also prevented the channel count increments to immediately be reflected in the recording node in the graph view.

fixes #244 #226 