### PR TITLE
fix release workflow version tagging

### DIFF
--- a/.changeset/red-crabs-deny.md
+++ b/.changeset/red-crabs-deny.md
@@ -1,0 +1,6 @@
+---
+"@rnbo-runner-panel/client": patch
+"@rnbo-runner-panel/server": patch
+---
+
+#296 Fix Release version tagging in release workflow

--- a/.github/workflows/release_cd.yml
+++ b/.github/workflows/release_cd.yml
@@ -77,6 +77,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.vstep.outputs.version }}
+          commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: "build/*.deb"
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepackage:linux": "npm run build:client && cross build --target aarch64-unknown-linux-gnu --release",
     "package:linux": "node scripts/package-linux.mjs arm64 ./build/linux-aarch64/ ./target/aarch64-unknown-linux-gnu/release/rnbo-runner-panel",
     "package:conan": "node scripts/package-conan.mjs",
-    "release": "changeset tag",
+    "release": "changeset publish",
     "version-packages": "changeset version && node ./scripts/apply-version.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #296 