### PR TITLE
Reset Instances upon receiving unload messages

### DIFF
--- a/client/src/actions/graph.ts
+++ b/client/src/actions/graph.ts
@@ -38,6 +38,7 @@ const patcherInstanceCoordinatesStore = new TempPatcherInstanceCoordinatesStore(
 
 export enum GraphActionType {
 
+	RESET_INSTANCE_NODES = "RESET_INSTANCE_NODES",
 	SET_NODE = "SET_NODE",
 	SET_NODES = "SET_NODES",
 	DELETE_NODE = "DELETE_NODE",
@@ -57,6 +58,11 @@ export enum GraphActionType {
 	SET_PORTS = "SET_PORTS",
 	DELETE_PORT = "DELETE_PORT",
 	DELETE_PORTS = "DELETE_PORTS",
+}
+
+export interface IResetGraphInstanceNodes extends ActionBase {
+	type: GraphActionType.RESET_INSTANCE_NODES;
+	payload: Record<string, never>;
 }
 
 export interface ISetGraphNode extends ActionBase {
@@ -171,11 +177,18 @@ export interface IDeleteGraphPorts extends ActionBase {
 	};
 }
 
-export type GraphAction = ISetGraphNode | ISetGraphNodes | IDeleteGraphNode | IDeleteGraphNodes
+export type GraphAction = ISetGraphNode | IResetGraphInstanceNodes | ISetGraphNodes | IDeleteGraphNode | IDeleteGraphNodes
 | ISetGraphNodePosition | ISetGraphNodePositions | IDeleteGraphNodePosition | IDeleteGraphNodePositions
 | ISetGraphConnection  | IDeleteGraphConnection | ISetGraphConnections  | IDeleteGraphConnections
 | ISetGraphPort | ISetGraphPorts | IDeleteGraphPort | IDeleteGraphPorts;
 
+
+export const resetInstanceNodes = (): IResetGraphInstanceNodes => {
+	return {
+		type: GraphActionType.RESET_INSTANCE_NODES,
+		payload: {}
+	};
+};
 
 export const setNode = (node: GraphNodeRecord): GraphAction => {
 	return {

--- a/client/src/actions/patchers.ts
+++ b/client/src/actions/patchers.ts
@@ -25,6 +25,7 @@ import { getCurrentPathname } from "../routes";
 export enum PatcherActionType {
 	INIT_PATCHERS = "INIT_PATCHERS",
 
+	RESET_INSTANCES = "RESET_INSTANCES",
 	SET_INSTANCE = "SET_INSTANCE",
 	SET_INSTANCES = "SET_INSTANCES",
 	DELETE_INSTANCE = "DELETE_INSTANCE",
@@ -56,6 +57,11 @@ export interface IInitPatchers extends ActionBase {
 	payload: {
 		patchers: PatcherExportRecord[];
 	};
+}
+
+export interface IResetInstances extends ActionBase {
+	type: PatcherActionType.RESET_INSTANCES;
+	payload: Record<string, never>;
 }
 
 export interface ISetInstance extends ActionBase {
@@ -198,7 +204,7 @@ export interface IDeleteInstanceDataRefs extends ActionBase {
 	};
 }
 
-export type InstanceAction = IInitPatchers | ISetInstance | ISetInstances | IDeleteInstance | IDeleteInstances |
+export type InstanceAction = IInitPatchers | IResetInstances | ISetInstance | ISetInstances | IDeleteInstance | IDeleteInstances |
 ISetInstanceParameter | ISetInstanceParameters | IDeleteInstanceParameter | IDeleteInstanceParameters |
 ISetInstanceMessageInport | ISetInstanceMessageInports | IDeleteInstanceMessageInport | IDeleteInstanceMessageInports |
 ISetInstanceMessageOutport | ISetInstanceMessageOutports | IDeleteInstanceMessageOutport | IDeleteInstanceMessageOutports |
@@ -447,6 +453,13 @@ export const initInstances = (instanceInfo: OSCQueryRNBOInstancesState): AppThun
 		dispatch(setInstanceMessageOutports(instanceMessageOutports));
 		dispatch(setInstanceDataRefs(instanceDataRefs));
 	};
+
+export const resetInstances = (): IResetInstances => {
+	return {
+		type: PatcherActionType.RESET_INSTANCES,
+		payload: {}
+	};
+};
 
 // Trigger Events on Remote OSCQuery Runner
 export const changeAliasOnRemoteInstance = (instance: PatcherInstanceRecord): AppThunk =>

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,5 +1,5 @@
 import { Provider } from "react-redux";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { RouterProvider } from "react-router";
 
 import { oscQueryBridge, parseConnectionQueryString } from "./controller/oscqueryBridgeController";
@@ -18,12 +18,15 @@ import TransportControl from "./components/page/transport";
 
 export const App = () => {
 
-	useEffect(() => {
-		oscQueryBridge.connect(parseConnectionQueryString(location.search?.slice(1)))
-			.catch((err): null => null); // handled internally
+	const [isSetup, setIsSetup] = useState<boolean>(false);
 
-		return () => oscQueryBridge.close();
-	}, []);
+	useEffect(() => {
+		if (isSetup) {
+			oscQueryBridge.connect(parseConnectionQueryString(location.search?.slice(1)))
+				.catch((err): null => null); // handled internally
+		}
+		setIsSetup(true);
+	}, [isSetup]);
 
 	return (
 		<>

--- a/client/src/controller/oscqueryBridgeController.ts
+++ b/client/src/controller/oscqueryBridgeController.ts
@@ -6,8 +6,8 @@ import { AppDispatch, store } from "../lib/store";
 import { ReconnectingWebsocket } from "../lib/reconnectingWs";
 import { AppStatus, JackInfoKey, RunnerCmdHighWaterMarkCount, RunnerCmdMethod, RunnerCmdResultCode, RunnerCmdWriteMethod, SystemInfoKey, WebSocketState } from "../lib/constants";
 import { OSCQueryRNBOState, OSCQueryRNBOInstance, OSCQueryRNBOPatchersState, OSCValue, OSCQueryRNBOInstancesMetaState, OSCQuerySetMeta, RunnerCmdResponse } from "../lib/types";
-import { deletePortAliases, initConnections, initPorts, setPortAliases, updateSetMetaFromRemote, updateSourcePortConnections, deletePortById, setPortProperties, addPort } from "../actions/graph";
-import { addInstance, deleteInstanceById, initInstances, initPatchers, removeInstanceDataRefByPath, updateInstanceDataRefMeta, updateInstanceDataRefs, updateInstanceParameterDisplayName, updateInstanceAlias } from "../actions/patchers";
+import { deletePortAliases, initConnections, initPorts, setPortAliases, updateSetMetaFromRemote, updateSourcePortConnections, deletePortById, setPortProperties, addPort, resetInstanceNodes } from "../actions/graph";
+import { addInstance, deleteInstanceById, initInstances, initPatchers, removeInstanceDataRefByPath, updateInstanceDataRefMeta, updateInstanceDataRefs, updateInstanceParameterDisplayName, updateInstanceAlias, resetInstances } from "../actions/patchers";
 import { initRunnerConfig, updateRunnerConfig } from "../actions/settings";
 import { initSets, setCurrentGraphSet, initSetPresets, setGraphSetPresetLatest, initSetViews, updateSetViewName, updateSetViewParameterList, deleteSetView, addSetView, updateSetViewOrder, setCurrentGraphSetDirtyState, setGraphSetInitialSet } from "../actions/sets";
 import { triggerDataFileListRefresh } from "../actions/datafiles";
@@ -601,6 +601,14 @@ export class OSCQueryBridgeControllerPrivate {
 	}
 
 	private async _processOSCMessage(packet: OSCMessage): Promise<void> {
+
+		if (packet.address === "/rnbo/inst/control/unload" && packet.args?.length === 1 && packet.args[0] as unknown as number === -1) {
+			// Unloading the graph so we have to reset the instance state
+			// as the runner is not tearing down things individually here
+			this.dispatch(resetInstanceNodes());
+			this.dispatch(resetInstances());
+			return;
+		}
 
 		if (packet.address === "/rnbo/jack/restart") {
 			return void this.dispatch(showNotification({ title: "Restarting Jack", message: "Please wait while the Jack server is being restarted with the updated audio configuration settings.", level: NotificationLevel.info }));

--- a/client/src/reducers/graph.ts
+++ b/client/src/reducers/graph.ts
@@ -32,6 +32,22 @@ export const graph = (state: GraphState = {
 
 	switch (action.type) {
 
+		case GraphActionType.RESET_INSTANCE_NODES: {
+			const nodeIds = state.patcherNodeIdByInstanceId.valueSeq().toArray();
+			const portIds = state.ports.filter(p => nodeIds.includes(p.nodeId)).keySeq().toArray();
+
+			return {
+				...state,
+				connections: state.connections
+					.filter(connection => !portIds.includes(connection.sourcePortId) && !portIds.includes(connection.sinkPortId)),
+				nodes: state.nodes.deleteAll(nodeIds),
+				nodePositions: state.nodePositions.deleteAll(nodeIds),
+				patcherNodeIdByInstanceId: ImmuMap<GraphNodeRecord["instanceId"], GraphNodeRecord["id"]>(),
+				ports: state.ports.deleteAll(portIds)
+
+			};
+		}
+
 		case GraphActionType.DELETE_NODE: {
 			const { node } = action.payload;
 			const portIds = state.ports.filter(p => p.nodeId === node.id).keySeq().toArray();

--- a/client/src/reducers/patchers.ts
+++ b/client/src/reducers/patchers.ts
@@ -37,6 +37,17 @@ export const patchers = (state: PatcherState = {
 			};
 		}
 
+		case PatcherActionType.RESET_INSTANCES: {
+			return {
+				...state,
+				instances: ImmuMap<PatcherInstanceRecord["id"], PatcherInstanceRecord>(),
+				instanceDataRefs: ImmuMap<DataRefRecord["id"], DataRefRecord>(),
+				instanceMessageInports: ImmuMap<MessagePortRecord["id"], MessagePortRecord>(),
+				instanceMessageOutports: ImmuMap<MessagePortRecord["id"], MessagePortRecord>(),
+				instanceParameters: ImmuMap<ParameterRecord["id"], ParameterRecord>()
+			};
+		}
+
 		case PatcherActionType.SET_INSTANCE: {
 			const { instance } = action.payload;
 


### PR DESCRIPTION
See #229 

OK. So I can reproduce this with creating a new graph, but it doesn't happen when switching between graphs. Looking at the incoming OSC messages I think it's bc in contrast to switching graphs the runner doesn't send the teardown messages for the instances in the graph and instead just "unloads" the set. I've made some progress on addressing this via this PR:

However, when you look at the incoming OSC messages there is actually a timing issue going on. The runner sends the `/rnbo/inst/control/unload` message with `[-1]` as the argument list, which is great. The web interface cleans up the instance state and nodes and we are all set to go. Prior to this change due to the missing teardown that wasn't cleaned up and all info preserved. However, after that the runner send messages for all the ports from the unloaded graph again to set their properties etc, which effectively recreates the ports and nodes in the graph. The only difference now on that branch is that the connections, position information etc is cleaned up.

Is there a way to suppress these messages once the graph has been unloaded @x37v ? It seems somewhat counterintuitive to receive port properties and information about the previous state after unloading the graph.