### PR TITLE
Show current parameter value in label

### DIFF
--- a/.changeset/show-param-value.md
+++ b/.changeset/show-param-value.md
@@ -1,0 +1,5 @@
+---
+"@rnbo-runner-panel/client": patch
+---
+
+Show current parameter value inline in the parameter label. Reduced font size of slider mark labels for better visual balance.

--- a/client/src/components/parameter/item.tsx
+++ b/client/src/components/parameter/item.tsx
@@ -131,15 +131,16 @@ const ParameterItem: FC<ParameterItemProps> = memo(function WrappedParameter({
 				) : null
 			}
 			<Group justify="space-between">
-				<Tooltip label={ indicatorText } disabled={ !indicatorText }>
+				<Tooltip label={ indicatorText } disabled={ !indicatorText } style={{ minWidth: 0, overflow: "hidden" }}>
 					<Indicator
 						position="middle-end"
 						disabled={ !indicatorText }
 						classNames={{ root: classes.parameterItemMIDIIndicator }}
+						style={{ overflow: "hidden", minWidth: 0 }}
 					>
 						<label htmlFor={ param.name } className={ classes.parameterItemLabel } >
-							{ displayName }
-							<span style={{ fontWeight: "normal" }}>{ `: ${formatParamValueForDisplay(value)}` }</span>
+							<span className={ classes.parameterItemLabelName }>{ displayName }</span>
+							<span className={ classes.parameterItemLabelValue }>{ formatParamValueForDisplay(value) }</span>
 						</label>
 					</Indicator>
 				</Tooltip>

--- a/client/src/components/parameter/item.tsx
+++ b/client/src/components/parameter/item.tsx
@@ -131,12 +131,11 @@ const ParameterItem: FC<ParameterItemProps> = memo(function WrappedParameter({
 				) : null
 			}
 			<Group justify="space-between">
-				<Tooltip label={ indicatorText } disabled={ !indicatorText } style={{ minWidth: 0, overflow: "hidden" }}>
+				<Tooltip label={ indicatorText } disabled={ !indicatorText }>
 					<Indicator
 						position="middle-end"
 						disabled={ !indicatorText }
 						classNames={{ root: classes.parameterItemMIDIIndicator }}
-						style={{ overflow: "hidden", minWidth: 0 }}
 					>
 						<label htmlFor={ param.name } className={ classes.parameterItemLabel } >
 							<span className={ classes.parameterItemLabelName }>{ displayName }</span>
@@ -171,7 +170,7 @@ const ParameterItem: FC<ParameterItemProps> = memo(function WrappedParameter({
 				<Menu position="bottom-end" disabled={ disabled } >
 					<Menu.Target>
 						<Tooltip label="Open Parameter Menu" disabled={ disabled }>
-							<ActionIcon variant="subtle" color="gray" size="md" disabled={ disabled } >
+							<ActionIcon variant="subtle" color="gray" size={ 28 } disabled={ disabled } >
 								<IconElement path={ mdiDotsVertical } />
 							</ActionIcon>
 						</Tooltip>

--- a/client/src/components/parameter/item.tsx
+++ b/client/src/components/parameter/item.tsx
@@ -139,6 +139,7 @@ const ParameterItem: FC<ParameterItemProps> = memo(function WrappedParameter({
 					>
 						<label htmlFor={ param.name } className={ classes.parameterItemLabel } >
 							{ displayName }
+							<span style={{ fontWeight: "normal" }}>{ `: ${formatParamValueForDisplay(value)}` }</span>
 						</label>
 					</Indicator>
 				</Tooltip>

--- a/client/src/components/parameter/parameters.module.css
+++ b/client/src/components/parameter/parameters.module.css
@@ -54,6 +54,8 @@
 	display: flex;
 	align-items: baseline;
 	gap: .5em;
+	justify-content: space-between;
+	padding-right: calc(28px + var(--mantine-spacing-md));
 	font-size: var(--mantine-font-size-sm);
 	font-weight: 700;
 	overflow: hidden;
@@ -73,6 +75,10 @@
 	flex-shrink: 0;
 }
 
+.markLabel {
+	font-size: var(--mantine-font-size-xs);
+}
+
 .markWrapper {
 
 	&:first-child {
@@ -90,7 +96,11 @@
 
 .parameterItemMIDIIndicator {
 	--indicator-size: 8px;
-	--indicator-translate-x: 150%!important;
-	--indicator-translate-y: -40%!important;
+	--indicator-translate-x: 150% !important;
+	--indicator-translate-y: -40% !important;
 	--indicator-color: var(--mantine-color-violet-4);
+	max-width: 100%;
+	min-width: 0;
+	overflow: hidden;
+	width: 100%;
 }

--- a/client/src/components/parameter/parameters.module.css
+++ b/client/src/components/parameter/parameters.module.css
@@ -51,11 +51,26 @@
 }
 
 .parameterItemLabel {
+	display: flex;
+	align-items: baseline;
+	gap: .5em;
 	font-size: var(--mantine-font-size-sm);
 	font-weight: 700;
 	overflow: hidden;
-	text-overflow: ellipsis;
 	user-select: none;
+}
+
+.parameterItemLabelName {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.parameterItemLabelValue {
+	font-weight: 400;
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 .markWrapper {


### PR DESCRIPTION
Display the current formatted parameter value next to the parameter name in the label (using normal font weight to distinguish it from the bold parameter name)

**Summary**
Display the current formatted parameter value next to the parameter name in the parameter label, so the user can always see the current value without having to interact with the slider.

**Current behavior**
Currently, the parameter value is only visible in the slider tooltip during interaction. There is no way to see the current value of a parameter at a glance — the user must move the slider to reveal it.

## Proposed change
Added a `<span>` after the parameter display name showing the formatted current value (e.g. "frequency: 440.00"). The value uses normal font weight to visually distinguish it from the bold parameter name.

## Changes
- `src/components/parameter/item.tsx`: Added formatted value display  in the parameter label element.