### PR TITLE
Fix/crossfs

### DIFF
--- a/.changeset/eager-bats-decide.md
+++ b/.changeset/eager-bats-decide.md
@@ -1,0 +1,5 @@
+---
+"@rnbo-runner-panel/server": patch
+---
+
+Fixed 500 with file PUT when tmp and dest are on different filesystems

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -185,9 +185,17 @@ mod file {
             .await
             .map_err(|_| Status::FailedDependency)?;
 
-        file.persist_to(fullpath)
-            .await
-            .map_err(|_| Status::InternalServerError)?;
+        //persist_to doesn't work across filesystems, but it is faster
+        //so try that first and the fallback to copy_to
+        if let Err(e) = file.persist_to(&fullpath).await {
+            if e.kind() == std::io::ErrorKind::CrossesDevices {
+                file.copy_to(&fullpath)
+                    .await
+                    .map_err(|_| Status::InternalServerError)?;
+            } else {
+                return Err(Status::InternalServerError);
+            }
+        }
         Ok(Status::Created)
     }
 }


### PR DESCRIPTION
this fixes package installation on the pi when tmp is on a different file system. by default trixie is setup like that