### PR TITLE
Feature/package UUID

### DIFF
--- a/.changeset/plain-papers-start.md
+++ b/.changeset/plain-papers-start.md
@@ -1,0 +1,5 @@
+---
+"@rnbo-runner-panel/client": patch
+---
+
+Match package item UUIDs and detect/display install, skip, overwrite status on upload

--- a/client/src/actions/sets.ts
+++ b/client/src/actions/sets.ts
@@ -7,7 +7,7 @@ import { showNotification } from "./notifications";
 import { NotificationLevel } from "../models/notification";
 import { ParameterRecord } from "../models/parameter";
 import { getPatcherInstance, getPatcherInstanceParametersSortedByInstanceIdAndIndex } from "../selectors/patchers";
-import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewState, OSCQueryValueType } from "../lib/types";
+import { OSCQueryRNBOSetView, OSCQueryRNBOSetViewState, OSCQueryValueType, OSCQueryRNBOSetsState } from "../lib/types";
 import { getCurrentGraphSet, getCurrentGraphSetId, getCurrentGraphSetIsDirty, getGraphPresets, getGraphSet, getGraphSets, getGraphSetsSortedByName, getGraphSetView, getGraphSetViews, getInitialGraphSet, getSelectedGraphSetView } from "../selectors/sets";
 import { clamp, getUniqueName, instanceAndParamIndicesToSetViewEntry, sleep, validateGraphSetName, validatePresetName, validateSetViewName } from "../lib/util";
 import { setInstanceWaitingForMidiMappingOnRemote } from "./patchers";
@@ -19,6 +19,7 @@ import { setRunnerConfig } from "./settings";
 
 export enum GraphSetActionType {
 	INIT_SETS = "INIT_SETS",
+	UPDATE_SET = "UPDATE_SET",
 
 	SET_SET_CURRENT = "SET_SET_CURRENT",
 	SET_SET_CURRENT_DIRTY = "SET_SET_CURRENT_DIRTY",
@@ -39,6 +40,14 @@ export interface IInitGraphSets extends ActionBase {
 	type: GraphSetActionType.INIT_SETS;
 	payload: {
 		sets: GraphSetRecord[]
+	}
+}
+
+export interface IUpdateGraphSet extends ActionBase {
+	type: GraphSetActionType.UPDATE_SET;
+	payload: {
+		name: string;
+		uuid: string;
 	}
 }
 
@@ -114,15 +123,33 @@ export interface ISetGraphSetViewOrder extends ActionBase {
 }
 
 
-export type GraphSetAction = IInitGraphSets | ISetGraphSetCurrent | ISetGraphSetCurrentDirty | ISetGraphSetInitial |
+export type GraphSetAction = IInitGraphSets | IUpdateGraphSet | ISetGraphSetCurrent | ISetGraphSetCurrentDirty | ISetGraphSetInitial |
 IInitGraphSetPresets | ISetGraphSetPresetsLatest |
 IInitGraphSetViews | ILoadGraphSetView | ISetGraphSetView | IDeleteGraphSetView | ISetGraphSetViewOrder;
 
-export const initSets = (names: string[]): GraphSetAction => {
+export const initSets = (entries: string[] | OSCQueryRNBOSetsState): GraphSetAction => {
+	let sets: GraphSetRecord[] = [];
+	if (Array.isArray(entries)) {
+		sets = entries.map(n => GraphSetRecord.fromDescription(n));
+	} else {
+		for (const [name, desc] of Object.entries(entries.CONTENTS || {})) {
+			sets.push(GraphSetRecord.fromDescription(name, desc.CONTENTS.uuid.VALUE));
+		}
+	}
 	return {
 		type: GraphSetActionType.INIT_SETS,
 		payload: {
-			sets: names.map(n => GraphSetRecord.fromDescription(n))
+			sets
+		}
+	};
+};
+
+export const updateSetUUID = (name: string, uuid: string): GraphSetAction => {
+	return {
+		type: GraphSetActionType.UPDATE_SET,
+		payload: {
+			name,
+			uuid
 		}
 	};
 };

--- a/client/src/components/package/uploadModal.tsx
+++ b/client/src/components/package/uploadModal.tsx
@@ -3,14 +3,14 @@ import { FC, FormEvent, memo, ReactNode, useCallback, useState } from "react";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice";
 import { FileWithPath } from "@mantine/dropzone";
 import { IconElement } from "../elements/icon";
-import { mdiAlertCircleOutline, mdiClose, mdiFileExport, mdiFileMusic, mdiGroup, mdiLoading, mdiPackageUp, mdiUpload } from "@mdi/js";
+import { mdiAlertCircleOutline, mdiClose, mdiFileExport, mdiFileMusic, mdiGroup, mdiInformationVariantCircleOutline, mdiLoading, mdiPackageUp, mdiUpload } from "@mdi/js";
 import { useAppSelector } from "../../hooks/useAppDispatch";
 import { TableHeaderCell } from "../elements/tableHeaderCell";
 import { ResourceType, SystemInfoKey } from "../../lib/constants";
 import { FileDropZone } from "../page/fileDropZone";
 import { getRunnerInfoRecord, getRunnerOrigin } from "../../selectors/appStatus";
 import { PackageInfoRecord } from "../../models/packageInfo";
-import { getPackageUploadConflicts, PackageUploadConflicts, readInfoFromPackageFile } from "../../lib/package";
+import { getPackageInstallStatus, PackageInstallStatus, PackageItemInstallStatus, readInfoFromPackageFile } from "../../lib/package";
 import { getDataFiles } from "../../selectors/datafiles";
 import { getPatcherExports } from "../../selectors/patchers";
 import { getGraphSets } from "../../selectors/sets";
@@ -28,11 +28,9 @@ export type UploadFile = {
 }
 
 type PackageContentItemProps = {
-	hasConflict: boolean;
+	status?: PackageItemInstallStatus;
 	resourceType: ResourceType;
 	title: string;
-	conflictText?: string;
-	conflictColor?: string;
 };
 
 const resourceTypeDisplay: Record<ResourceType, ReactNode> = {
@@ -91,26 +89,28 @@ const InfoCard: FC<InfoCardProps> = ({
 };
 
 const PackageContentItem: FC<PackageContentItemProps> = ({
-	hasConflict,
+	status,
 	resourceType,
-	title,
-	conflictText,
-	conflictColor
+	title
 }) => {
+	const isoverwrite = status === PackageItemInstallStatus.Overwrite;
 	return (
 		<Table.Tr>
 			<Table.Td valign="top" >{ resourceTypeDisplay[resourceType] }</Table.Td>
 			<Table.Td valign="top" >
 				{ title }
 				{
-					hasConflict ? (
-						<Text c={ conflictColor || "red" } fz="xs" component="div" >
+					status === PackageItemInstallStatus.Install ? null : (
+						<Text c={ isoverwrite ? "red" : "yellow" } fz="xs" component="div" >
 							<Group gap={ 2 } align="center">
-								<IconElement path={ mdiAlertCircleOutline } />
-								<span>{ conflictText || "An upload will overwrite the existing resource." }</span>
+								<IconElement path={ isoverwrite ? mdiAlertCircleOutline : mdiInformationVariantCircleOutline } />
+								<span>{ isoverwrite ?
+									"An upload will overwrite the existing resource." :
+									"An upload skip overwriting this existing resource." }
+								</span>
 							</Group>
 						</Text>
-					) : null
+					)
 				}
 			</Table.Td>
 		</Table.Tr>
@@ -118,7 +118,7 @@ const PackageContentItem: FC<PackageContentItemProps> = ({
 };
 
 type PackageUploadConfirmFormProps = {
-	conflicts: PackageUploadConflicts;
+	status: PackageInstallStatus;
 	info: PackageInfoRecord;
 	onCancel: () => void;
 	onSubmit: () => void;
@@ -127,7 +127,7 @@ type PackageUploadConfirmFormProps = {
 };
 
 const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
-	conflicts,
+	status,
 	info,
 	onCancel,
 	onSubmit,
@@ -188,11 +188,9 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 								info.datafiles.map(df => (
 									<PackageContentItem
 										key={ `df_${df.id}`}
-										hasConflict={ conflicts.datafiles.includes(df.name) }
+										status={ status.datafiles.get(df.name) }
 										resourceType={ ResourceType.DataFile }
 										title={ df.name }
-										conflictText="Datafile will not be overwritten"
-										conflictColor="yellow"
 									/>
 								))
 							}
@@ -200,7 +198,7 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 								info.patchers.map(patcher => (
 									<PackageContentItem
 										key={ `patcher_${patcher.id}`}
-										hasConflict={ conflicts.patchers.includes(patcher.name) }
+										status={ status.patchers.get(patcher.name) }
 										resourceType={ ResourceType.Patcher }
 										title={ patcher.name }
 									/>
@@ -210,7 +208,7 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 								info.sets.map(set => (
 									<PackageContentItem
 										key={ `set${set.id}`}
-										hasConflict={ conflicts.sets.includes(set.name) }
+										status={ status.sets.get(set.name) }
 										resourceType={ ResourceType.Set }
 										title={ set.name }
 									/>
@@ -269,7 +267,7 @@ interface PackageUploadSelectState {
 
 interface PackageUploadConfirmState {
 	step: PackageUploadStep.Confirm;
-	conflicts: PackageUploadConflicts;
+	status: PackageInstallStatus;
 	pkgInfo: PackageInfoRecord;
 	file: File;
 }
@@ -327,7 +325,7 @@ export const PackageUploadModal: FC<PackageUploadModalProps> = memo(function Wra
 			if (file.name.split(".").pop() !== PACKAGE_EXTENSION) throw new Error(`${file.name} is not a ${PACKAGE_EXTENSION} file`);
 			const pkgInfo = PackageInfoRecord.fromDescription(await readInfoFromPackageFile(file));
 			setUploadState({
-				conflicts: getPackageUploadConflicts(pkgInfo, datafiles, patcherExports, graphSets),
+				status: getPackageInstallStatus(pkgInfo, datafiles, patcherExports, graphSets),
 				file,
 				pkgInfo,
 				step: PackageUploadStep.Confirm
@@ -384,7 +382,7 @@ export const PackageUploadModal: FC<PackageUploadModalProps> = memo(function Wra
 		}
 		case PackageUploadStep.Confirm: {
 			content = <PackageUploadConfirmForm
-				conflicts={ uploadState.conflicts }
+				status={ uploadState.status }
 				info={ uploadState.pkgInfo }
 				onCancel={ onCancel }
 				onSubmit={ onSubmit }

--- a/client/src/components/package/uploadModal.tsx
+++ b/client/src/components/package/uploadModal.tsx
@@ -1,9 +1,9 @@
-import { Alert, Button, Center, Fieldset, Group, Modal, Paper, RingProgress, Stack, Table, Text } from "@mantine/core";
+import { Alert, Badge, Button, Center, Fieldset, Group, Modal, Paper, RingProgress, Stack, Table, Text } from "@mantine/core";
 import { FC, FormEvent, memo, ReactNode, useCallback, useState } from "react";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice";
 import { FileWithPath } from "@mantine/dropzone";
 import { IconElement } from "../elements/icon";
-import { mdiAlertCircleOutline, mdiClose, mdiFileExport, mdiFileMusic, mdiGroup, mdiInformationVariantCircleOutline, mdiLoading, mdiPackageUp, mdiUpload } from "@mdi/js";
+import { mdiClose, mdiEqual, mdiFileExport, mdiFileMusic, mdiGroup, mdiInformationOutline, mdiLoading, mdiPackageUp, mdiPlus, mdiReloadAlert, mdiUpload } from "@mdi/js";
 import { useAppSelector } from "../../hooks/useAppDispatch";
 import { TableHeaderCell } from "../elements/tableHeaderCell";
 import { ResourceType, SystemInfoKey } from "../../lib/constants";
@@ -33,23 +33,41 @@ type PackageContentItemProps = {
 	title: string;
 };
 
+const resourceStatusBadge: Record<PackageItemUploadStatus, ReactNode> = {
+	[PackageItemUploadStatus.Install]: (
+		<Badge leftSection={<IconElement path={mdiPlus} />} variant="light" size="sm" color="green">New</Badge>
+	),
+	[PackageItemUploadStatus.Skip]: (
+		<Badge leftSection={<IconElement path={mdiEqual} />} variant="light" size="sm" color="gray">Skip</Badge>
+	),
+	[PackageItemUploadStatus.Overwrite]: (
+		<Badge leftSection={<IconElement path={mdiReloadAlert} />} variant="light" size="sm" color="yellow">Overwrite</Badge>
+	)
+};
+
+const resourceTypeTitle: Record<ResourceType, string> = {
+	[ResourceType.DataFile]: "Data File",
+	[ResourceType.Patcher]: "Patcher",
+	[ResourceType.Set]: "Graph"
+};
+
 const resourceTypeDisplay: Record<ResourceType, ReactNode> = {
 	[ResourceType.DataFile]: (
 		<Group gap={ 2 } align="center" >
 			<IconElement path={ mdiFileMusic } />
-			<span>Data File</span>
+			<span>{ resourceTypeTitle[ResourceType.DataFile] }</span>
 		</Group>
 	),
 	[ResourceType.Patcher]: (
 		<Group gap={ 2 } align="center" >
 			<IconElement path={ mdiFileExport } />
-			<span>Patcher</span>
+			<span>{ resourceTypeTitle[ResourceType.Patcher] }</span>
 		</Group>
 	),
 	[ResourceType.Set]: (
 		<Group gap={ 2 } align="center" >
 			<IconElement path={ mdiGroup } />
-			<span>Graph</span>
+			<span>{ resourceTypeTitle[ResourceType.Set] }</span>
 		</Group>
 	)
 };
@@ -93,27 +111,53 @@ const PackageContentItem: FC<PackageContentItemProps> = ({
 	resourceType,
 	title
 }) => {
-	const isoverwrite = status === PackageItemUploadStatus.Overwrite;
+
 	return (
 		<Table.Tr>
+			<Table.Td valign="top" >{ resourceStatusBadge[status] }</Table.Td>
 			<Table.Td valign="top" >{ resourceTypeDisplay[resourceType] }</Table.Td>
 			<Table.Td valign="top" >
 				{ title }
-				{
-					status === PackageItemUploadStatus.Install ? null : (
-						<Text c={ isoverwrite ? "red" : "yellow" } fz="xs" component="div" >
-							<Group gap={ 2 } align="center">
-								<IconElement path={ isoverwrite ? mdiAlertCircleOutline : mdiInformationVariantCircleOutline } />
-								<span>{ isoverwrite ?
-									"An upload will overwrite the existing resource." :
-									"An upload skip overwriting this existing resource." }
-								</span>
-							</Group>
-						</Text>
-					)
-				}
 			</Table.Td>
 		</Table.Tr>
+	);
+};
+
+type StatusCounts = Record<PackageItemUploadStatus, number>;
+
+type PackageUploadSummaryProps = {
+	counts: StatusCounts;
+};
+
+const PackageUploadSummary: FC<PackageUploadSummaryProps> = ({
+	counts
+}) => {
+
+	return (
+		<Stack gap="sm">
+			<Group grow>
+				{
+					[
+						{
+							statusField: PackageItemUploadStatus.Install,
+							props: { color: "green", title: "New" }
+						},
+						{
+							statusField: PackageItemUploadStatus.Skip,
+							props: { color: "gray", title: "Skip" }
+						},
+						{
+							statusField: PackageItemUploadStatus.Overwrite,
+							props: { color: "yellow", title: "Will Overwrite" }
+						}
+					].map(({ statusField, props } ) => counts[statusField] === 0 ? null : (
+						<Alert { ...props } key={ statusField } p="xs" variant="light">
+							<Text fz="lg" fw="bold" c={ props.color } >{ counts[statusField] }</Text>
+						</Alert>
+					))
+				}
+			</Group>
+		</Stack >
 	);
 };
 
@@ -140,7 +184,6 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 		onSubmit();
 	}, [onSubmit]);
 
-
 	const [
 		supportsUpload,
 		rnboVersion,
@@ -150,6 +193,27 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 		getRunnerInfoRecord(state, SystemInfoKey.RNBOVersion),
 		getRunnerInfoRecord(state, SystemInfoKey.RNBOCompatVersion)
 	]);
+
+	const statusCounts: Record<PackageItemUploadStatus, number> = {
+		[PackageItemUploadStatus.Install]: 0,
+		[PackageItemUploadStatus.Skip]: 0,
+		[PackageItemUploadStatus.Overwrite]: 0
+	};
+
+	info.datafiles.forEach(df => {
+		const itemStatus = status.datafiles.get(df.name);
+		statusCounts[itemStatus]++;
+	});
+
+	info.patchers.forEach(p => {
+		const itemStatus = status.patchers.get(p.name);
+		statusCounts[itemStatus]++;
+	});
+
+	info.sets.forEach(s => {
+		const itemStatus = status.sets.get(s.name);
+		statusCounts[itemStatus]++;
+	});
 
 	return (
 		<form onSubmit={ onTriggerSubmit } >
@@ -175,47 +239,60 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 						/>
 					</Stack>
 				</Fieldset>
+				{
+					statusCounts[PackageItemUploadStatus.Overwrite] !== 0 ? (
+						<Alert color="yellow" variant="outline" title="Package includes Overwrites" icon={<IconElement path={mdiInformationOutline} />} >
+							{statusCounts[PackageItemUploadStatus.Overwrite]} existing {statusCounts[PackageItemUploadStatus.Overwrite] === 1 ? "resource" : "resources"} will be replaced.
+							<br/>
+							Review the details below before continuing. This action cannot be undone.
+						</Alert>
+					) : null
+				}
 				<Fieldset legend="Contents" >
-					<Table>
-						<Table.Thead>
-							<Table.Tr>
-								<TableHeaderCell width={ 150 } >Type</TableHeaderCell>
-								<TableHeaderCell >Name</TableHeaderCell>
-							</Table.Tr>
-						</Table.Thead>
-						<Table.Tbody>
-							{
-								info.datafiles.map(df => (
-									<PackageContentItem
-										key={ `df_${df.id}`}
-										status={ status.datafiles.get(df.name) }
-										resourceType={ ResourceType.DataFile }
-										title={ df.name }
-									/>
-								))
-							}
-							{
-								info.patchers.map(patcher => (
-									<PackageContentItem
-										key={ `patcher_${patcher.id}`}
-										status={ status.patchers.get(patcher.name) }
-										resourceType={ ResourceType.Patcher }
-										title={ patcher.name }
-									/>
-								))
-							}
-							{
-								info.sets.map(set => (
-									<PackageContentItem
-										key={ `set${set.id}`}
-										status={ status.sets.get(set.name) }
-										resourceType={ ResourceType.Set }
-										title={ set.name }
-									/>
-								))
-							}
-						</Table.Tbody>
-					</Table>
+					<Stack gap="md">
+						<PackageUploadSummary counts={statusCounts } />
+						<Table verticalSpacing="xs" horizontalSpacing="xs" >
+							<Table.Thead>
+								<Table.Tr>
+									<TableHeaderCell width={ 120 } >Status</TableHeaderCell>
+									<TableHeaderCell width={ 150 } >Type</TableHeaderCell>
+									<TableHeaderCell>Name</TableHeaderCell>
+								</Table.Tr>
+							</Table.Thead>
+							<Table.Tbody>
+								{
+									info.datafiles.map(df => (
+										<PackageContentItem
+											key={ `df_${df.id}`}
+											status={ status.datafiles.get(df.name) }
+											resourceType={ ResourceType.DataFile }
+											title={ df.name }
+										/>
+									))
+								}
+								{
+									info.patchers.map(patcher => (
+										<PackageContentItem
+											key={ `patcher_${patcher.id}`}
+											status={ status.patchers.get(patcher.name) }
+											resourceType={ ResourceType.Patcher }
+											title={ patcher.name }
+										/>
+									))
+								}
+								{
+									info.sets.map(set => (
+										<PackageContentItem
+											key={ `set${set.id}`}
+											status={ status.sets.get(set.name) }
+											resourceType={ ResourceType.Set }
+											title={ set.name }
+										/>
+									))
+								}
+							</Table.Tbody>
+						</Table>
+					</Stack>
 				</Fieldset>
 				{
 					!supportsUpload ? (

--- a/client/src/components/package/uploadModal.tsx
+++ b/client/src/components/package/uploadModal.tsx
@@ -31,6 +31,8 @@ type PackageContentItemProps = {
 	hasConflict: boolean;
 	resourceType: ResourceType;
 	title: string;
+	conflictText?: string;
+	conflictColor?: string;
 };
 
 const resourceTypeDisplay: Record<ResourceType, ReactNode> = {
@@ -91,7 +93,9 @@ const InfoCard: FC<InfoCardProps> = ({
 const PackageContentItem: FC<PackageContentItemProps> = ({
 	hasConflict,
 	resourceType,
-	title
+	title,
+	conflictText,
+	conflictColor
 }) => {
 	return (
 		<Table.Tr>
@@ -100,10 +104,10 @@ const PackageContentItem: FC<PackageContentItemProps> = ({
 				{ title }
 				{
 					hasConflict ? (
-						<Text c="red" fz="xs" component="div" >
+						<Text c={ conflictColor || "red" } fz="xs" component="div" >
 							<Group gap={ 2 } align="center">
 								<IconElement path={ mdiAlertCircleOutline } />
-								<span>An upload will overwrite the existing resource.</span>
+								<span>{ conflictText || "An upload will overwrite the existing resource." }</span>
 							</Group>
 						</Text>
 					) : null
@@ -187,6 +191,8 @@ const PackageUploadConfirmForm: FC<PackageUploadConfirmFormProps> = ({
 										hasConflict={ conflicts.datafiles.includes(df.name) }
 										resourceType={ ResourceType.DataFile }
 										title={ df.name }
+										conflictText="Datafile will not be overwritten"
+										conflictColor="yellow"
 									/>
 								))
 							}

--- a/client/src/components/package/uploadModal.tsx
+++ b/client/src/components/package/uploadModal.tsx
@@ -10,7 +10,7 @@ import { ResourceType, SystemInfoKey } from "../../lib/constants";
 import { FileDropZone } from "../page/fileDropZone";
 import { getRunnerInfoRecord, getRunnerOrigin } from "../../selectors/appStatus";
 import { PackageInfoRecord } from "../../models/packageInfo";
-import { getPackageInstallStatus, PackageInstallStatus, PackageItemInstallStatus, readInfoFromPackageFile } from "../../lib/package";
+import { getPackageUploadStatus, PackageUploadStatus, PackageItemUploadStatus, readInfoFromPackageFile } from "../../lib/package";
 import { getDataFiles } from "../../selectors/datafiles";
 import { getPatcherExports } from "../../selectors/patchers";
 import { getGraphSets } from "../../selectors/sets";
@@ -28,7 +28,7 @@ export type UploadFile = {
 }
 
 type PackageContentItemProps = {
-	status?: PackageItemInstallStatus;
+	status?: PackageItemUploadStatus;
 	resourceType: ResourceType;
 	title: string;
 };
@@ -93,14 +93,14 @@ const PackageContentItem: FC<PackageContentItemProps> = ({
 	resourceType,
 	title
 }) => {
-	const isoverwrite = status === PackageItemInstallStatus.Overwrite;
+	const isoverwrite = status === PackageItemUploadStatus.Overwrite;
 	return (
 		<Table.Tr>
 			<Table.Td valign="top" >{ resourceTypeDisplay[resourceType] }</Table.Td>
 			<Table.Td valign="top" >
 				{ title }
 				{
-					status === PackageItemInstallStatus.Install ? null : (
+					status === PackageItemUploadStatus.Install ? null : (
 						<Text c={ isoverwrite ? "red" : "yellow" } fz="xs" component="div" >
 							<Group gap={ 2 } align="center">
 								<IconElement path={ isoverwrite ? mdiAlertCircleOutline : mdiInformationVariantCircleOutline } />
@@ -118,7 +118,7 @@ const PackageContentItem: FC<PackageContentItemProps> = ({
 };
 
 type PackageUploadConfirmFormProps = {
-	status: PackageInstallStatus;
+	status: PackageUploadStatus;
 	info: PackageInfoRecord;
 	onCancel: () => void;
 	onSubmit: () => void;
@@ -267,7 +267,7 @@ interface PackageUploadSelectState {
 
 interface PackageUploadConfirmState {
 	step: PackageUploadStep.Confirm;
-	status: PackageInstallStatus;
+	status: PackageUploadStatus;
 	pkgInfo: PackageInfoRecord;
 	file: File;
 }
@@ -325,7 +325,7 @@ export const PackageUploadModal: FC<PackageUploadModalProps> = memo(function Wra
 			if (file.name.split(".").pop() !== PACKAGE_EXTENSION) throw new Error(`${file.name} is not a ${PACKAGE_EXTENSION} file`);
 			const pkgInfo = PackageInfoRecord.fromDescription(await readInfoFromPackageFile(file));
 			setUploadState({
-				status: getPackageInstallStatus(pkgInfo, datafiles, patcherExports, graphSets),
+				status: getPackageUploadStatus(pkgInfo, datafiles, patcherExports, graphSets),
 				file,
 				pkgInfo,
 				step: PackageUploadStep.Confirm

--- a/client/src/controller/oscqueryBridgeController.ts
+++ b/client/src/controller/oscqueryBridgeController.ts
@@ -674,7 +674,7 @@ export class OSCQueryBridgeControllerPrivate {
 
 		const setUUIDMatch = packet.address.match(setsUUIDMatcher);
 		if (setUUIDMatch) {
-			const uuid: string = (packet.args as unknown as [string])[0]
+			const uuid: string = (packet.args as unknown as [string])[0];
 			return void this.dispatch(updateSetUUID(setUUIDMatch.groups.name, uuid));
 		}
 

--- a/client/src/controller/oscqueryBridgeController.ts
+++ b/client/src/controller/oscqueryBridgeController.ts
@@ -5,11 +5,11 @@ import { initRunnerInfo, setRunnerInfoValue, setAppStatus, setConnectionEndpoint
 import { AppDispatch, store } from "../lib/store";
 import { ReconnectingWebsocket } from "../lib/reconnectingWs";
 import { AppStatus, JackInfoKey, RunnerCmdHighWaterMarkCount, RunnerCmdMethod, RunnerCmdResultCode, RunnerCmdWriteMethod, SystemInfoKey, WebSocketState } from "../lib/constants";
-import { OSCQueryRNBOState, OSCQueryRNBOInstance, OSCQueryRNBOPatchersState, OSCValue, OSCQueryRNBOInstancesMetaState, OSCQuerySetMeta, RunnerCmdResponse } from "../lib/types";
+import { OSCQueryRNBOState, OSCQueryRNBOInstance, OSCQueryRNBOPatchersState, OSCQueryRNBOSetsState, OSCValue, OSCQueryRNBOInstancesMetaState, OSCQuerySetMeta, RunnerCmdResponse } from "../lib/types";
 import { deletePortAliases, initConnections, initPorts, setPortAliases, updateSetMetaFromRemote, updateSourcePortConnections, deletePortById, setPortProperties, addPort } from "../actions/graph";
 import { addInstance, deleteInstanceById, initInstances, initPatchers, removeInstanceDataRefByPath, updateInstanceDataRefMeta, updateInstanceDataRefs, updateInstanceParameterDisplayName, updateInstanceAlias } from "../actions/patchers";
 import { initRunnerConfig, updateRunnerConfig } from "../actions/settings";
-import { initSets, setCurrentGraphSet, initSetPresets, setGraphSetPresetLatest, initSetViews, updateSetViewName, updateSetViewParameterList, deleteSetView, addSetView, updateSetViewOrder, setCurrentGraphSetDirtyState, setGraphSetInitialSet } from "../actions/sets";
+import { initSets, updateSetUUID, setCurrentGraphSet, initSetPresets, setGraphSetPresetLatest, initSetViews, updateSetViewName, updateSetViewParameterList, deleteSetView, addSetView, updateSetViewOrder, setCurrentGraphSetDirtyState, setGraphSetInitialSet } from "../actions/sets";
 import { triggerDataFileListRefresh } from "../actions/datafiles";
 import { sleep } from "../lib/util";
 import { getPatcherInstance } from "../selectors/patchers";
@@ -108,6 +108,8 @@ enum OSCQueryCommand {
 const portPropertiesPathMatcher = /^\/rnbo\/jack\/info\/ports\/properties\/(?<port>.+)$/;
 const portAliasPathMatcher = /^\/rnbo\/jack\/info\/ports\/aliases\/(?<port>.+)$/;
 const patchersPathMatcher = /^\/rnbo\/patchers/;
+const setsPathMatcher = /^\/rnbo\/sets\/(?<name>.+)$/;
+const setsUUIDMatcher = /^\/rnbo\/sets\/(?<name>.+)\/uuid$/;
 const instancePathMatcher = /^\/rnbo\/inst\/(?<id>\d+)$/;
 const instanceStatePathMatcher = /^\/rnbo\/inst\/(?<id>\d+)\/(?<content>params|messages\/in|messages\/out|presets|data_refs|config|midi\/last)\/(?<rest>\S+)/;
 const instancePresetPathMatcher = /^\/rnbo\/inst\/(?<id>\d+)\/presets\/(?<property>loaded|initial)$/;
@@ -128,6 +130,7 @@ const runnerInfoMatcher = /^\/rnbo\/info\/(?<name>[^/]+)$/;
 export class OSCQueryBridgeControllerPrivate {
 
 	private _hasIsActive: boolean = false;
+	private _hasSetsEndpoint: boolean = false;
 
 	private readonly cmdResponseChunkProcessor: RunnerCmdResponseProcessor = new RunnerCmdResponseProcessor();
 	private readonly cmdWriteStreamLock: Map<RunnerCmdWriteMethod, string> = new Map();
@@ -320,7 +323,13 @@ export class OSCQueryBridgeControllerPrivate {
 		this.dispatch(initPatchers(state.CONTENTS.patchers));
 
 		// Init Sets info
-		this.dispatch(initSets(state.CONTENTS.inst?.CONTENTS?.control?.CONTENTS?.sets?.CONTENTS?.load?.RANGE?.[0]?.VALS || []));
+		if (state.CONTENTS?.sets) {
+			this._hasSetsEndpoint = true;
+			this.dispatch(initSets(state.CONTENTS.sets));
+		} else {
+			this._hasSetsEndpoint = false;
+			this.dispatch(initSets(state.CONTENTS.inst?.CONTENTS?.control?.CONTENTS?.sets?.CONTENTS?.load?.RANGE?.[0]?.VALS || []));
+		}
 		this.dispatch(setGraphSetInitialSet(state.CONTENTS.inst?.CONTENTS?.control?.CONTENTS?.sets?.CONTENTS?.initial?.VALUE));
 		this.dispatch(setCurrentGraphSet(state.CONTENTS.inst?.CONTENTS?.control?.CONTENTS?.sets?.CONTENTS?.current?.CONTENTS?.name?.VALUE || ""));
 		this.dispatch(setCurrentGraphSetDirtyState(state.CONTENTS.inst?.CONTENTS?.control?.CONTENTS?.sets?.CONTENTS?.current?.CONTENTS?.dirty?.TYPE === "T"));
@@ -421,6 +430,12 @@ export class OSCQueryBridgeControllerPrivate {
 			return void this.dispatch(initPatchers(patcherInfo));
 		}
 
+		// Added Set
+		if (setsPathMatcher.test(path)) {
+			const setInfo = await this._requestState<OSCQueryRNBOSetsState>("/rnbo/sets");
+			return void this.dispatch(initSets(setInfo));
+		}
+
 		// Handle Set Views
 		const setViewMatch = path.match(setViewPathMatcher);
 		if (setViewMatch && setViewMatch.groups?.rest === undefined) {
@@ -484,6 +499,12 @@ export class OSCQueryBridgeControllerPrivate {
 		if (patchersPathMatcher.test(path)) {
 			const patcherInfo = await this._requestState<OSCQueryRNBOPatchersState>("/rnbo/patchers");
 			return void this.dispatch(initPatchers(patcherInfo));
+		}
+
+		// Removed Set
+		if (setsPathMatcher.test(path)) {
+			const setInfo = await this._requestState<OSCQueryRNBOSetsState>("/rnbo/sets");
+			return void this.dispatch(initSets(setInfo));
 		}
 
 		// Removed Set View
@@ -567,7 +588,7 @@ export class OSCQueryBridgeControllerPrivate {
 
 	private async _onAttributesChanged(data: any): Promise<void> {
 		// console.log("ATTRIBUTES_CHANGED", data);
-		if (data.FULL_PATH === "/rnbo/inst/control/sets/load" && data.RANGE !== undefined) {
+		if (!this._hasSetsEndpoint && data.FULL_PATH === "/rnbo/inst/control/sets/load" && data.RANGE !== undefined) {
 			const sets: Array<string> = data.RANGE?.[0]?.VALS || [];
 			this.dispatch(initSets(sets));
 		}
@@ -649,6 +670,12 @@ export class OSCQueryBridgeControllerPrivate {
 		if (setMetaMatch) {
 			const meta: OSCQuerySetMeta = deserializeSetMeta((packet.args as unknown as [string])[0]);
 			return void this.dispatch(updateSetMetaFromRemote(meta));
+		}
+
+		const setUUIDMatch = packet.address.match(setsUUIDMatcher);
+		if (setUUIDMatch) {
+			const uuid: string = (packet.args as unknown as [string])[0]
+			return void this.dispatch(updateSetUUID(setUUIDMatch.groups.name, uuid));
 		}
 
 		if (packet.address === "/rnbo/inst/control/sets/views/order") {

--- a/client/src/lib/package.ts
+++ b/client/src/lib/package.ts
@@ -47,24 +47,24 @@ export async function readInfoFromPackageFile(file: File): Promise<RunnerPackage
 	return info;
 }
 
-export enum PackageItemInstallStatus {
+export enum PackageItemUploadStatus {
 	Install,
 	Overwrite,
 	Skip
 }
 
-export type PackageInstallStatus = {
-	datafiles: Map<DataFileRecord["fileName"], PackageItemInstallStatus>;
-	patchers: Map<PatcherExportRecord["name"], PackageItemInstallStatus>;
-	sets: Map<GraphSetRecord["name"], PackageItemInstallStatus>;
+export type PackageUploadStatus = {
+	datafiles: Map<DataFileRecord["fileName"], PackageItemUploadStatus>;
+	patchers: Map<PatcherExportRecord["name"], PackageItemUploadStatus>;
+	sets: Map<GraphSetRecord["name"], PackageItemUploadStatus>;
 };
 
-export const getPackageInstallStatus = (
+export const getPackageUploadStatus = (
 	uploadInfo: PackageInfoRecord,
 	datafiles: ImmuMap<DataFileRecord["id"], DataFileRecord>,
 	patcherExports: ImmuMap<PatcherExportRecord["id"], PatcherExportRecord>,
 	graphSets: ImmuMap<GraphSetRecord["id"], GraphSetRecord>
-): PackageInstallStatus => {
+): PackageUploadStatus => {
 	const datafilestatus = new Map();
 	const patchersstatus = new Map();
 	const setsstatus = new Map();
@@ -72,24 +72,24 @@ export const getPackageInstallStatus = (
 	for (const e of uploadInfo?.datafiles || []) {
 		// datafiles don't yet have a uuid or md5, they're just skipped if they already exist
 		const existing = datafiles.find(d => d.fileName === e.name);
-		const s = existing ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Install;
+		const s = existing ? PackageItemUploadStatus.Skip : PackageItemUploadStatus.Install;
 		datafilestatus.set(e.name, s);
 	}
 
 	for (const e of uploadInfo?.patchers || []) {
-		let s = PackageItemInstallStatus.Install;
+		let s = PackageItemUploadStatus.Install;
 		const existing = patcherExports.find(d => d.name === e.name);
 		if (existing) {
-			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Overwrite;
+			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemUploadStatus.Skip : PackageItemUploadStatus.Overwrite;
 		}
 		patchersstatus.set(e.name, s);
 	}
 
 	for (const e of uploadInfo?.sets || []) {
-		let s = PackageItemInstallStatus.Install;
+		let s = PackageItemUploadStatus.Install;
 		const existing = graphSets.find(d => d.name === e.name);
 		if (existing) {
-			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Overwrite;
+			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemUploadStatus.Skip : PackageItemUploadStatus.Overwrite;
 		}
 		setsstatus.set(e.name, s);
 	}

--- a/client/src/lib/package.ts
+++ b/client/src/lib/package.ts
@@ -65,7 +65,7 @@ export const getPackageUploadConflicts = (
 			.filter(d => !!d)
 			.toArray() || [],
 		patchers: uploadInfo?.patchers
-			.map(pkgP => patcherExports.find(p => p.name === pkgP.name)?.name)
+			.map(pkgP => patcherExports.find(p => (p.name === pkgP.name && (p.uuid === undefined || pkgP.uuid === undefined || p.uuid !== pkgP.uuid)))?.name)
 			.filter(p => !!p)
 			.toArray() || [],
 		sets: uploadInfo?.sets

--- a/client/src/lib/package.ts
+++ b/client/src/lib/package.ts
@@ -47,31 +47,57 @@ export async function readInfoFromPackageFile(file: File): Promise<RunnerPackage
 	return info;
 }
 
-export type PackageUploadConflicts = {
-	datafiles: Array<DataFileRecord["fileName"]>;
-	patchers: Array<PatcherExportRecord["name"]>;
-	sets: Array<GraphSetRecord["name"]>;
+export enum PackageItemInstallStatus {
+	Install,
+	Overwrite,
+	Skip
+}
+
+export type PackageInstallStatus = {
+	datafiles: Map<DataFileRecord["fileName"], PackageItemInstallStatus>;
+	patchers: Map<PatcherExportRecord["name"], PackageItemInstallStatus>;
+	sets: Map<GraphSetRecord["name"], PackageItemInstallStatus>;
 };
 
-export const getPackageUploadConflicts = (
+export const getPackageInstallStatus = (
 	uploadInfo: PackageInfoRecord,
 	datafiles: ImmuMap<DataFileRecord["id"], DataFileRecord>,
 	patcherExports: ImmuMap<PatcherExportRecord["id"], PatcherExportRecord>,
 	graphSets: ImmuMap<GraphSetRecord["id"], GraphSetRecord>
-): PackageUploadConflicts => {
+): PackageInstallStatus => {
+	const datafilestatus = new Map();
+	const patchersstatus = new Map();
+	const setsstatus = new Map();
+
+	for (const e of uploadInfo?.datafiles || []) {
+		// datafiles don't yet have a uuid or md5, they're just skipped if they already exist
+		const existing = datafiles.find(d => d.fileName === e.name);
+		const s = existing ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Install;
+		datafilestatus.set(e.name, s);
+	}
+
+	for (const e of uploadInfo?.patchers || []) {
+		let s = PackageItemInstallStatus.Install;
+		const existing = patcherExports.find(d => d.name === e.name);
+		if (existing) {
+			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Overwrite;
+		}
+		patchersstatus.set(e.name, s);
+	}
+
+	for (const e of uploadInfo?.sets || []) {
+		let s = PackageItemInstallStatus.Install;
+		const existing = graphSets.find(d => d.name === e.name);
+		if (existing) {
+			s = (existing.uuid && e.uuid && e.uuid === existing.uuid) ? PackageItemInstallStatus.Skip : PackageItemInstallStatus.Overwrite;
+		}
+		setsstatus.set(e.name, s);
+	}
+
 	return {
-		datafiles: uploadInfo?.datafiles
-			.map(pkgD => datafiles.find(d => d.fileName === pkgD.name)?.fileName)
-			.filter(d => !!d)
-			.toArray() || [],
-		patchers: uploadInfo?.patchers
-			.map(pkgP => patcherExports.find(p => (p.name === pkgP.name && (!p.uuid || !pkgP.uuid || p.uuid !== pkgP.uuid)))?.name)
-			.filter(p => !!p)
-			.toArray() || [],
-		sets: uploadInfo?.sets
-			.map(pkgS => graphSets.find(s => (s.name === pkgS.name && (!s.uuid || !pkgS.uuid || s.uuid !== pkgS.uuid)))?.name)
-			.filter(s => !!s)
-			.toArray() || []
+		datafiles: datafilestatus,
+		patchers: patchersstatus,
+		sets: setsstatus
 	};
 };
 

--- a/client/src/lib/package.ts
+++ b/client/src/lib/package.ts
@@ -65,11 +65,11 @@ export const getPackageUploadConflicts = (
 			.filter(d => !!d)
 			.toArray() || [],
 		patchers: uploadInfo?.patchers
-			.map(pkgP => patcherExports.find(p => (p.name === pkgP.name && (p.uuid === undefined || pkgP.uuid === undefined || p.uuid !== pkgP.uuid)))?.name)
+			.map(pkgP => patcherExports.find(p => (p.name === pkgP.name && (!p.uuid || !pkgP.uuid || p.uuid !== pkgP.uuid)))?.name)
 			.filter(p => !!p)
 			.toArray() || [],
 		sets: uploadInfo?.sets
-			.map(pkgS => graphSets.find(s => s.name === pkgS.name)?.name)
+			.map(pkgS => graphSets.find(s => (s.name === pkgS.name && (!s.uuid || !pkgS.uuid || s.uuid !== pkgS.uuid)))?.name)
 			.filter(s => !!s)
 			.toArray() || []
 	};

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -389,6 +389,16 @@ export type OSCQueryRNBOPatchersState = OSCQueryBaseNode & {
 	CONTENTS: Record<string, OSCQueryRNBOPatcher>;
 };
 
+export type OSCQueryRNBOSet = OSCQueryBaseNode & {
+	CONTENTS: {
+		uuid: OSCQueryStringValue | undefined;
+	};
+}
+
+export type OSCQueryRNBOSetsState = OSCQueryBaseNode & {
+	CONTENTS: Record<string, OSCQueryRNBOSet>;
+};
+
 export type OSCQueryRNBOInstanceParameterValue = OSCQueryBaseNode & OSCQueryFloatValue & OSCQueryValueRange & {
 	CONTENTS: {
 		display_name: OSCQueryStringValue;
@@ -570,6 +580,7 @@ export type OSCQueryRNBOState = OSCQueryBaseNode & {
 		config: OSCQueryRNBOConfigState;
 		jack: OSCQueryRNBOJackState;
 		patchers: OSCQueryRNBOPatchersState;
+		sets: OSCQueryRNBOSetsState | undefined;
 		inst: OSCQueryRNBOInstancesState;
 		info: OSCQueryRNBOInfoState;
 	};

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -122,12 +122,16 @@ export type RunnerPackagePatcherInfo = {
 	name: string;
 	patcher: string;
 	presets: string;
+	uuid: string | undefined;
+	rnbo_version: string | undefined;
+	rnbo_compat_version: string | undefined;
 };
 
 export type RunnerPackageSetInfo = {
 	created_at: string;
 	location: string;
 	name: string;
+	uuid: string | undefined;
 };
 
 export type RunnerPackageTargetInfo = {
@@ -376,6 +380,7 @@ export type OSCQueryRNBOPatcher = OSCQueryBaseNode & {
 	CONTENTS: {
 		io: OSCQueryListValue<"iiii", [number, number, number, number]>;
 		created_at: OSCQueryStringValue;
+		uuid: OSCQueryStringValue | undefined;
 		destroy: OSCQueryInfValue;
 	};
 }

--- a/client/src/models/packageInfo.ts
+++ b/client/src/models/packageInfo.ts
@@ -28,7 +28,10 @@ export class PackagePatcherInfoRecord extends ImmuRecord<PackagePatcherInfoRecor
 	created_at: "",
 	name: "",
 	patcher: "",
-	presets: ""
+	presets: "",
+	uuid: undefined,
+	rnbo_version: undefined,
+	rnbo_compat_version: undefined
 }) {
 
 	public static fromDescription(desc: RunnerPackagePatcherInfo): PackagePatcherInfoRecord {
@@ -52,7 +55,8 @@ export type PackageSetInfoRecordProps = RunnerPackageSetInfo;
 export class PackageSetInfoRecord extends ImmuRecord<PackageSetInfoRecordProps>({
 	created_at: "",
 	location: "",
-	name: ""
+	name: "",
+	uuid: undefined
 }) {
 
 	public static fromDescription(desc: RunnerPackageSetInfo): PackageSetInfoRecord {

--- a/client/src/models/patcher.ts
+++ b/client/src/models/patcher.ts
@@ -9,13 +9,15 @@ export type PatcherExportRecordProps = {
 	createdAt: Dayjs;
 	name: string;
 	io: [number, number, number, number];
+	uuid: string | undefined;
 }
 
 export class PatcherExportRecord extends ImmuRecord<PatcherExportRecordProps>({
 
 	createdAt: dayjs(),
 	name: "",
-	io: [0, 0, 0, 0]
+	io: [0, 0, 0, 0],
+	uuid: undefined
 
 }) {
 
@@ -23,7 +25,8 @@ export class PatcherExportRecord extends ImmuRecord<PatcherExportRecordProps>({
 		return new PatcherExportRecord({
 			createdAt: dayjs(desc.CONTENTS.created_at?.VALUE, "YYYY-MM-DD HH:mm:ss"),
 			name,
-			io: desc.CONTENTS.io.VALUE
+			io: desc.CONTENTS.io.VALUE,
+			uuid: desc.CONTENTS.uuid?.VALUE
 		});
 	}
 

--- a/client/src/models/set.ts
+++ b/client/src/models/set.ts
@@ -5,14 +5,16 @@ import { ParameterRecord } from "./parameter";
 
 export type GraphSetRecordProps = {
 	name: string;
+	uuid: string | undefined;
 };
 
 export class GraphSetRecord extends ImmuRecord<GraphSetRecordProps>({
-	name: ""
+	name: "",
+	uuid: undefined
 }) {
 
-	public static fromDescription(name: string): GraphSetRecord {
-		return new GraphSetRecord({ name });
+	public static fromDescription(name: string, uuid?: string): GraphSetRecord {
+		return new GraphSetRecord({ name, uuid });
 	}
 
 	get id(): string {

--- a/client/src/reducers/sets.ts
+++ b/client/src/reducers/sets.ts
@@ -48,6 +48,17 @@ export const sets = (state: SetState = {
 			};
 		}
 
+		case GraphSetActionType.UPDATE_SET: {
+			const { name, uuid } = action.payload;
+
+			return {
+				...state,
+				sets: state.sets.withMutations(map => {
+					map.set(name, GraphSetRecord.fromDescription(name, uuid));
+				})
+			};
+		}
+
 		case GraphSetActionType.INIT_SET_PRESETS: {
 			const { presets } = action.payload;
 


### PR DESCRIPTION
This adds support for patcher uuid and set uuid matching while uploading packages, adding some additional fields to the patcher and set entries.
It changes the upload modal to indicate if items will be skipped or overwritten.

<img width="634" height="746" alt="image" src="https://github.com/user-attachments/assets/77863433-d310-434a-adb2-bd03bd405014" />

## TODO 

support datafile sub directories (the jack smith entry should match and be skipped)