### PR TITLE
chore: move changelog generation to @changesets/changelog-github

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,11 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-	"changelog": "@changesets/cli/changelog",
+	"changelog": [
+		"@changesets/changelog-github",
+		{
+			"repo": "Cycling74/rnbo-runner-panel"
+		}
+	],
 	"commit": false,
 	"fixed": [
 		["@rnbo-runner-panel/client", "@rnbo-runner-panel/server"]

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,8 @@
 	"changelog": [
 		"@changesets/changelog-github",
 		{
-			"repo": "Cycling74/rnbo-runner-panel"
+			"repo": "Cycling74/rnbo-runner-panel",
+			"disableThanks": true
 		}
 	],
 	"commit": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,13 @@
         "server"
       ],
       "devDependencies": {
+        "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.29.8"
       }
     },
     "client": {
       "name": "@rnbo-runner-panel/client",
-      "version": "2.1.1-beta.12",
+      "version": "2.3.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@mantine/core": "^7.10.2",
@@ -540,6 +541,18 @@
         "@changesets/types": "^6.1.0"
       }
     },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.6.0.tgz",
+      "integrity": "sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.8.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
     "node_modules/@changesets/cli": {
       "version": "2.29.8",
       "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz",
@@ -617,6 +630,17 @@
         "@manypkg/get-packages": "^1.1.3",
         "picocolors": "^1.1.0",
         "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.8.0.tgz",
+      "integrity": "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -4337,6 +4361,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -4496,6 +4527,16 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -6860,6 +6901,27 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
@@ -9211,6 +9273,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -9741,6 +9810,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9950,7 +10037,7 @@
     },
     "server": {
       "name": "@rnbo-runner-panel/server",
-      "version": "2.1.1-beta.12"
+      "version": "2.3.1"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
         "server"
       ],
       "devDependencies": {
-        "@changesets/changelog-github": "^0.6.0",
+        "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.29.8"
       }
     },
     "client": {
       "name": "@rnbo-runner-panel/client",
-      "version": "2.3.1",
+      "version": "2.4.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "@mantine/core": "^7.10.2",
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@changesets/changelog-github": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.6.0.tgz",
-      "integrity": "sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.7.0.tgz",
+      "integrity": "sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10037,7 +10037,7 @@
     },
     "server": {
       "name": "@rnbo-runner-panel/server",
-      "version": "2.3.1"
+      "version": "2.4.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "version-packages": "changeset version && node ./scripts/apply-version.mjs"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.29.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "version-packages": "changeset version && node ./scripts/apply-version.mjs"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.6.0",
+    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.29.8"
   }
 }


### PR DESCRIPTION
This way the changelog should automatically link PRs and give credits to contributors.

Skipped the changesets version bump given that it's more of a devops chore change.