### PR TITLE
Fix MIDI indicator horizontal overflow

### DIFF
--- a/.changeset/fix-midi-indicator-overflow.md
+++ b/.changeset/fix-midi-indicator-overflow.md
@@ -1,0 +1,5 @@
+---
+"@rnbo-runner-panel/client": patch
+---
+
+Fix MIDI indicator dot overflowing horizontally outside the parameter box.

--- a/.changeset/fix-midi-indicator-overflow.md
+++ b/.changeset/fix-midi-indicator-overflow.md
@@ -2,4 +2,4 @@
 "@rnbo-runner-panel/client": patch
 ---
 
-Fix MIDI indicator dot overflowing horizontally outside the parameter box.
+Fix MIDI indicator dot overflowing horizontally outside the parameter box. Thanks @fcana

--- a/client/src/components/parameter/parameters.module.css
+++ b/client/src/components/parameter/parameters.module.css
@@ -96,7 +96,7 @@
 
 .parameterItemMIDIIndicator {
 	--indicator-size: 8px;
-	--indicator-translate-x: 150% !important;
+	--indicator-translate-x: -130% !important;
 	--indicator-translate-y: -40% !important;
 	--indicator-color: var(--mantine-color-violet-4);
 	max-width: 100%;

--- a/client/src/components/parameter/parameters.module.css
+++ b/client/src/components/parameter/parameters.module.css
@@ -96,8 +96,9 @@
 
 .parameterItemMIDIIndicator {
 	--indicator-size: 8px;
-	--indicator-translate-x: -130% !important;
-	--indicator-translate-y: -40% !important;
+	/* shifted by half the button size and then centered */
+	--indicator-translate-x: calc(-14px + 50%) !important;
+	--indicator-translate-y: -50% !important;
 	--indicator-color: var(--mantine-color-violet-4);
 	max-width: 100%;
 	min-width: 0;


### PR DESCRIPTION
Follow-up to #321: the `width: 100%` added to `.parameterItemMIDIIndicator` for name ellipsis pushed the MIDI indicator dot to the column edge, where it overflowed horizontally. This adjusts `--indicator-translate-x` so the dot sits within the row.

The purple dot is now placed over the three dot menu, for not conflicting with parameter name or parameter value.

The tooltip still triggers on the full label row and stays centered (it wraps the full-width Indicator root)... left minimal here, happy to follow up if a different hover target is preferred